### PR TITLE
Fix help of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ help:
 	@echo '  clean            - Remove all build artifacts'
 	@echo '  check|test       - Run all tests'
 	@echo '  lint             - Run code quality checks'
-	@echo '  protos           - Generate protobuf messages'
-	@echo '  mocks            - Generate the gomock files'
 	@echo '  generate         - Generate dependent files'
 	@echo ''
 	@echo 'Specific targets:'


### PR DESCRIPTION
Target `protos` and `mocks` are described in the help but are not defined in the Makefile. This patch delete the non-existent targets from the help.