### PR TITLE
CircleCI: Upgrade to SGX SDK 2.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             sudo apt-get update -q
             sudo apt-get install -qy --no-install-recommends ca-certificates build-essential python wget git make pkg-config
-            wget "https://download.01.org/intel-sgx/linux-2.1.1/ubuntu64-server/sgx_linux_x64_sdk_2.1.101.42529.bin" -O sgx_installer.bin
+            wget "https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin" -O sgx_installer.bin
             chmod +x sgx_installer.bin
             echo -e "no\n$(dirname $SGX_SDK)" | sudo ./sgx_installer.bin
             rm sgx_installer.bin


### PR DESCRIPTION
As mentioned in #31, SGX SDK 2.3.1 includes a patch that can remove our workarounds. This PR upgrades the SDK used in the CI.