### PR TITLE
remove workaround for simulation mode of SGX SDK

### DIFF
--- a/sample/authentication/crypto_test.go
+++ b/sample/authentication/crypto_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,12 +83,6 @@ func testUSIGAuthenScheme(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping USIG enclave recreation in short mode.")
 	}
-	// The USIG enclave might have been built in simulation mode.
-	// Apparently, SGX SDK in the simulation mode uses current
-	// time in *seconds* to seed random number generation. We need
-	// to wait at least one second to ensure that the enclave gets
-	// a unique epoch in that case.
-	time.Sleep(time.Second)
 
 	usig2, err := sgxusig.New(usigEnclaveFile, usig1.SealedKey())
 	require.NoError(t, err)

--- a/sample/authentication/keymanager.go
+++ b/sample/authentication/keymanager.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"time"
 
 	"github.com/hyperledger-labs/minbft/api"
 	sgxusig "github.com/hyperledger-labs/minbft/usig/sgx"
@@ -310,13 +309,6 @@ func (spec *sgxEcdsaKeySpec) parsePrivateKey(privKeyStr string) (interface{}, er
 // generateKeyPair creates an SGX USIG instance to generate a key
 // pair, where the private key is sealed by the enclave.
 func (spec *sgxEcdsaKeySpec) generateKeyPair(securityParam int) (string, string, error) {
-	// HACK: The USIG enclave might have been built in simulation
-	// mode. SGX SDK uses current time in *seconds* to seed random
-	// number generation in the simulation mode. We need to wait
-	// for at least one second to ensure that the enclave
-	// generates a unique key pair in that case.
-	time.Sleep(time.Second)
-
 	usig, err := sgxusig.New(spec.enclaveFile, nil)
 	if err != nil {
 		return "", "", err

--- a/usig/sgx/test/usig_test.c
+++ b/usig/sgx/test/usig_test.c
@@ -97,15 +97,11 @@ static void test_create_ui()
         assert(usig_create_ui(usig, digest, &c3, &s3) == SGX_SUCCESS);
         // Must fetch a fresh counter value
         assert(c3 == 1);
-#ifndef SGX_SIM_MODE
-        // Apparently, SGX SDK in the simulation mode uses current
-        // time in *seconds* to seed random number generation. We
-        // don't want to wait that long and skip these checks.
+
         // Check for uniqueness of the epoch and certificate produced
         // by the new instance of the enclave
         assert(e1 != e2);
         assert(!signature_is_equal(&s1, &s3));
-#endif
 
         assert(usig_destroy(usig) == SGX_SUCCESS);
         free(sealed_data);


### PR DESCRIPTION
This PR resolves #31. With this change, unit test runs faster.