### PR TITLE
CircleCI: Update CI Environment to Ubuntu 18.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/hyperledger-labs/minbft
     docker:
-      - image: circleci/buildpack-deps:xenial
+      - image: circleci/buildpack-deps:bionic
     environment:
       SGX_SDK: /opt/intel/sgxsdk
     steps:
@@ -20,7 +20,7 @@ jobs:
           command: |
             sudo apt-get update -q
             sudo apt-get install -qy --no-install-recommends ca-certificates build-essential python wget git make pkg-config
-            wget "https://download.01.org/intel-sgx/linux-2.3.1/ubuntu16.04/sgx_linux_x64_sdk_2.3.101.46683.bin" -O sgx_installer.bin
+            wget "https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin" -O sgx_installer.bin
             chmod +x sgx_installer.bin
             echo -e "no\n$(dirname $SGX_SDK)" | sudo ./sgx_installer.bin
             rm sgx_installer.bin

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Byzantine Fault-Tolerance paper][minbft-paper].
 
 ### Operating System ###
 
-The project has been tested on Ubuntu 16.04.4 LTS (Xenial Xerus).
+The project has been tested on Ubuntu 18.04 LTS (Bionic Beaver).
 Additional required packages can be installed as follows:
 
 ```sh


### PR DESCRIPTION
Intel SGX SDK 2.3 support Ubuntu 18.04. We can update the CI environment.