### PR TITLE
peer/cmd: add logging-related command line options

### DIFF
--- a/core/replica.go
+++ b/core/replica.go
@@ -69,7 +69,10 @@ func New(id uint32, configer api.Configer, stack Stack) (*Replica, error) {
 		log: messagelog.New(),
 	}
 
-	logger := makeLogger(id)
+	logger, err := makeLogger(id)
+	if err != nil {
+		return nil, err
+	}
 	handle := defaultIncomingMessageHandler(id, replica.log, configer, stack, logger)
 	replica.handleStream = makeMessageStreamHandler(handle, logger)
 

--- a/sample/peer/cmd/root.go
+++ b/sample/peer/cmd/root.go
@@ -67,6 +67,14 @@ func init() {
 	rootCmd.PersistentFlags().String("keys", defKeysFile, "keyset file")
 	must(viper.BindPFlag("keys",
 		rootCmd.PersistentFlags().Lookup("keys")))
+
+	rootCmd.PersistentFlags().String("logging-level", "", "logging level")
+	must(viper.BindPFlag("logging.level",
+		rootCmd.PersistentFlags().Lookup("logging-level")))
+
+	rootCmd.PersistentFlags().String("logging-file", "", "logging file")
+	must(viper.BindPFlag("logging.file",
+		rootCmd.PersistentFlags().Lookup("logging-file")))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Here's a patch for issue #42. I commented that log prefix format can also be configurable, but it's not included finally because in my second thought default prefix string seems good enough.