### PR TITLE
peer/cmd: add logging-related command line options (v2)

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -1,0 +1,55 @@
+// Copyright © 2018 NEC Solution Innovators, Ltd.
+//
+// Authors: Naoya Horiguchi <n-horiguchi@ah.jp.nec.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minbft
+
+import (
+	"os"
+
+	logging "github.com/op/go-logging"
+)
+
+type Options struct {
+	LogLevel  logging.Level
+	LogFile   *os.File
+}
+
+type Option func(*Options)
+
+func newOptions(opts ...Option) Options {
+    opt := Options{
+        LogLevel:    logging.DEBUG,
+        LogFile:     os.Stdout,
+    }
+
+    for _, o := range opts {
+        o(&opt)
+    }
+
+    return opt
+}
+
+func WithLogLevel(l logging.Level) Option {
+	return func(opts *Options) {
+		opts.LogLevel = l
+	}
+}
+
+func WithLogFile(f *os.File) Option {
+	return func(opts *Options) {
+		opts.LogFile = f
+	}
+}

--- a/core/replica.go
+++ b/core/replica.go
@@ -52,13 +52,15 @@ type Replica struct {
 }
 
 // New creates a new instance of replica node
-func New(id uint32, configer api.Configer, stack Stack) (*Replica, error) {
+func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (*Replica, error) {
 	n := configer.N()
 	f := configer.F()
 
 	if n < 2*f+1 {
 		return nil, fmt.Errorf("%d nodes is not enough to tolerate %d faulty", n, f)
 	}
+
+	options := newOptions(opts...)
 
 	replica := &Replica{
 		id: id,
@@ -69,7 +71,7 @@ func New(id uint32, configer api.Configer, stack Stack) (*Replica, error) {
 		log: messagelog.New(),
 	}
 
-	logger := makeLogger(id)
+	logger := makeLogger(id, options)
 	handle := defaultIncomingMessageHandler(id, replica.log, configer, stack, logger)
 	replica.handleStream = makeMessageStreamHandler(handle, logger)
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -19,7 +19,6 @@ package minbft
 
 import (
 	"fmt"
-	"os"
 
 	logging "github.com/op/go-logging"
 
@@ -112,17 +111,17 @@ func messageString(msg interface{}) string {
 	return "(unknown message)"
 }
 
-func makeLogger(id uint32) *logging.Logger {
+func makeLogger(id uint32, opts Options) *logging.Logger {
 	logger := logging.MustGetLogger(module)
 	logFormatString := fmt.Sprintf("%s Replica %d: %%{message}", defaultLogPrefix, id)
 	stringFormatter := logging.MustStringFormatter(logFormatString)
-	backend := logging.NewLogBackend(os.Stdout, "", 0)
+	backend := logging.NewLogBackend(opts.LogFile, "", 0)
 	backendFormatter := logging.NewBackendFormatter(backend, stringFormatter)
 	formattedLoggerBackend := logging.AddModuleLevel(backendFormatter)
 
 	logger.SetBackend(formattedLoggerBackend)
 
-	formattedLoggerBackend.SetLevel(logging.DEBUG, module)
+	formattedLoggerBackend.SetLevel(opts.LogLevel, module)
 
 	return logger
 }

--- a/sample/peer/cmd/root.go
+++ b/sample/peer/cmd/root.go
@@ -67,6 +67,14 @@ func init() {
 	rootCmd.PersistentFlags().String("keys", defKeysFile, "keyset file")
 	must(viper.BindPFlag("keys",
 		rootCmd.PersistentFlags().Lookup("keys")))
+
+	rootCmd.PersistentFlags().String("logging-level", "", "logging level")
+	must(viper.BindPFlag("logging.level",
+		rootCmd.PersistentFlags().Lookup("logging-level")))
+
+	rootCmd.PersistentFlags().String("logging-file", "", "logging file")
+	must(viper.BindPFlag("logging.file",
+		rootCmd.PersistentFlags().Lookup("logging-file")))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Version 2 of #44 for original issue #42. The main change is to separate option parser code from core package by applying "functional options" pattern.