### PR TITLE
peer/cmd: add logging-related command line options (v3)

### DIFF
--- a/core/options.go
+++ b/core/options.go
@@ -1,0 +1,32 @@
+// Copyright © 2018 NEC Solution Innovators, Ltd.
+//
+// Authors: Naoya Horiguchi <n-horiguchi@ah.jp.nec.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minbft
+
+type options struct{}
+
+// Option represents function type to set options.
+type Option func(*options)
+
+func newOptions(opts ...Option) options {
+	opt := options{}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	return opt
+}

--- a/core/options.go
+++ b/core/options.go
@@ -16,17 +16,43 @@
 
 package minbft
 
-type options struct{}
+import (
+	"os"
+
+	logging "github.com/op/go-logging"
+)
+
+type options struct {
+	logLevel logging.Level
+	logFile  *os.File
+}
 
 // Option represents function type to set options.
 type Option func(*options)
 
 func newOptions(opts ...Option) options {
-	opt := options{}
+	opt := options{
+		logLevel: logging.DEBUG,
+		logFile:  os.Stdout,
+	}
 
 	for _, o := range opts {
 		o(&opt)
 	}
 
 	return opt
+}
+
+// WithLogLevel sets logging level
+func WithLogLevel(l logging.Level) Option {
+	return func(opts *options) {
+		opts.logLevel = l
+	}
+}
+
+// WithLogFile sets file path of logging file
+func WithLogFile(f *os.File) Option {
+	return func(opts *options) {
+		opts.logFile = f
+	}
 }

--- a/core/replica.go
+++ b/core/replica.go
@@ -60,6 +60,8 @@ func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (*Replic
 		return nil, fmt.Errorf("%d nodes is not enough to tolerate %d faulty", n, f)
 	}
 
+	logOpts := newOptions(opts...)
+
 	replica := &Replica{
 		id: id,
 		n:  n,
@@ -69,7 +71,7 @@ func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (*Replic
 		log: messagelog.New(),
 	}
 
-	logger := makeLogger(id)
+	logger := makeLogger(id, logOpts)
 	handle := defaultIncomingMessageHandler(id, replica.log, configer, stack, logger)
 	replica.handleStream = makeMessageStreamHandler(handle, logger)
 

--- a/core/replica.go
+++ b/core/replica.go
@@ -52,7 +52,7 @@ type Replica struct {
 }
 
 // New creates a new instance of replica node
-func New(id uint32, configer api.Configer, stack Stack) (*Replica, error) {
+func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (*Replica, error) {
 	n := configer.N()
 	f := configer.F()
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -19,7 +19,6 @@ package minbft
 
 import (
 	"fmt"
-	"os"
 
 	logging "github.com/op/go-logging"
 
@@ -112,17 +111,17 @@ func messageString(msg interface{}) string {
 	return "(unknown message)"
 }
 
-func makeLogger(id uint32) *logging.Logger {
+func makeLogger(id uint32, opts options) *logging.Logger {
 	logger := logging.MustGetLogger(module)
 	logFormatString := fmt.Sprintf("%s Replica %d: %%{message}", defaultLogPrefix, id)
 	stringFormatter := logging.MustStringFormatter(logFormatString)
-	backend := logging.NewLogBackend(os.Stdout, "", 0)
+	backend := logging.NewLogBackend(opts.logFile, "", 0)
 	backendFormatter := logging.NewBackendFormatter(backend, stringFormatter)
 	formattedLoggerBackend := logging.AddModuleLevel(backendFormatter)
 
 	logger.SetBackend(formattedLoggerBackend)
 
-	formattedLoggerBackend.SetLevel(logging.DEBUG, module)
+	formattedLoggerBackend.SetLevel(opts.logLevel, module)
 
 	return logger
 }


### PR DESCRIPTION
This is version 3 of issue #42.
Based on Sergey's feedbacks, I added some changes below:

- separate the patch into 3 (each for small logical steps)
- make type Options private
- move flag definition code to sample/peer/cmd/run.go
- introduce getLoggingOptions() (we maybe have chance to reuse it later)
- make some refactoring to satisfy gometalinter (fix indent/spacing, add comment on exported type/functions, avoid shadow declaration warning)

Previous versions: v1 #44, v2 #45.