### PR TITLE
CircleCI: Use Custom Docker Image v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,39 +3,16 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/hyperledger-labs/minbft
     docker:
-      - image: circleci/buildpack-deps:bionic
-    environment:
-      SGX_SDK: /opt/intel/sgxsdk
+      - image: necblockchain/minbft
     steps:
-      - run:
-          name: Install Go
-          command: |
-            wget "https://golang.org/dl/go1.10.3.linux-amd64.tar.gz" -O golang.tar.gz
-            sudo tar -C /usr/local -xaf golang.tar.gz
-            rm golang.tar.gz
-            echo 'export GOPATH=$HOME/go' >> $BASH_ENV
-            echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BASH_ENV
-      - run:
-          name: Install Intel SGX SDK
-          command: |
-            sudo apt-get update -q
-            sudo apt-get install -qy --no-install-recommends ca-certificates build-essential python wget git make pkg-config
-            wget "https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin" -O sgx_installer.bin
-            chmod +x sgx_installer.bin
-            echo -e "no\n$(dirname $SGX_SDK)" | sudo ./sgx_installer.bin
-            rm sgx_installer.bin
-            echo '. $SGX_SDK/environment' >> $BASH_ENV
-      - run:
-          name: Install gometalinter
-          command: |
-            go get -u github.com/alecthomas/gometalinter
-            gometalinter --install
       - checkout
       - run:
           name: Test
+          shell: /bin/bash -leo pipefail
           command: |
             make build check SGX_MODE=SIM
       - run:
           name: Lint
+          shell: /bin/bash -leo pipefail
           command: |
             make lint || : allow failure

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -1,0 +1,26 @@
+FROM circleci/buildpack-deps:bionic-curl
+
+RUN sudo apt-get update \
+  && sudo apt-get install -y \
+    pkg-config
+
+RUN GO_URL="https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz" \
+  && curl $GO_URL | sudo tar -C /usr/local -xzf - \
+  && echo 'export GOPATH="$HOME/go"' | sudo tee -a /etc/profile > /dev/null \
+  && echo 'export PATH="/usr/local/go/bin:$PATH"' | sudo tee -a /etc/profile > /dev/null
+
+RUN SGX_SDK_URL="https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin" \
+  && sudo apt-get install -y \
+    build-essential \
+    python \
+  && curl $SGX_SDK_URL -o /tmp/sgx_linux_x64_sdk.bin \
+  && chmod +x /tmp/sgx_linux_x64_sdk.bin \
+  && echo -e "no\n/opt/intel" | sudo /tmp/sgx_linux_x64_sdk.bin \
+  && rm -f /tmp/sgx_linux_x64_sdk.bin \
+  && echo 'source /opt/intel/sgxsdk/environment' | sudo tee -a /etc/profile > /dev/null
+
+RUN GOMETALINTER_URL="https://github.com/alecthomas/gometalinter/releases/download/v2.0.11/gometalinter-2.0.11-linux-amd64.tar.gz" \
+  && curl -L $GOMETALINTER_URL | sudo tar -C /opt -xzf - \
+  && echo 'export PATH="/opt/gometalinter-2.0.11-linux-amd64:$PATH"' | sudo tee -a /etc/profile > /dev/null
+
+RUN echo 'export PATH="$GOPATH/bin:$PATH"' | sudo tee -a /etc/profile > /dev/null


### PR DESCRIPTION
Currently, the CI sets up an environment (Go, Intel SGX SDK, etc.) from a fresh Ubuntu image everytime.

This patch introduces a custom Docker image, which contains everything used to build and test our project. By using this image, the CI can skip the environment setup and do just build and test in a CI process; saving resource and time.

Changes from v1 (#48):
- Reorganize commits
- Update the commit comment