### PR TITLE
CircleCI: Use Custom Docker Image v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,39 +3,16 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/hyperledger-labs/minbft
     docker:
-      - image: circleci/buildpack-deps:bionic
-    environment:
-      SGX_SDK: /opt/intel/sgxsdk
+      - image: necblockchain/minbft
     steps:
-      - run:
-          name: Install Go
-          command: |
-            wget "https://golang.org/dl/go1.10.3.linux-amd64.tar.gz" -O golang.tar.gz
-            sudo tar -C /usr/local -xaf golang.tar.gz
-            rm golang.tar.gz
-            echo 'export GOPATH=$HOME/go' >> $BASH_ENV
-            echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH' >> $BASH_ENV
-      - run:
-          name: Install Intel SGX SDK
-          command: |
-            sudo apt-get update -q
-            sudo apt-get install -qy --no-install-recommends ca-certificates build-essential python wget git make pkg-config
-            wget "https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin" -O sgx_installer.bin
-            chmod +x sgx_installer.bin
-            echo -e "no\n$(dirname $SGX_SDK)" | sudo ./sgx_installer.bin
-            rm sgx_installer.bin
-            echo '. $SGX_SDK/environment' >> $BASH_ENV
-      - run:
-          name: Install gometalinter
-          command: |
-            go get -u github.com/alecthomas/gometalinter
-            gometalinter --install
       - checkout
       - run:
           name: Test
+          shell: /bin/bash -leo pipefail
           command: |
             make build check SGX_MODE=SIM
       - run:
           name: Lint
+          shell: /bin/bash -leo pipefail
           command: |
             make lint || : allow failure

--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -1,0 +1,24 @@
+FROM circleci/buildpack-deps:bionic-curl
+
+RUN sudo apt-get update \
+  && sudo apt-get install -y \
+    pkg-config
+
+RUN GO_URL="https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz" \
+  && curl $GO_URL | sudo tar -C /usr/local -xzf -
+COPY go.sh /etc/profile.d/
+
+RUN SGX_SDK_URL="https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin" \
+  && sudo apt-get install -y \
+    build-essential \
+    python \
+  && curl $SGX_SDK_URL -o /tmp/sgx_linux_x64_sdk.bin \
+  && chmod +x /tmp/sgx_linux_x64_sdk.bin \
+  && echo -e "no\n/opt/intel" | sudo /tmp/sgx_linux_x64_sdk.bin \
+  && rm -f /tmp/sgx_linux_x64_sdk.bin \
+  && sudo ln -s /opt/intel/sgxsdk/environment /etc/profile.d/intel-sgxsdk.sh
+
+RUN GOMETALINTER_URL="https://github.com/alecthomas/gometalinter/releases/download/v2.0.11/gometalinter-2.0.11-linux-amd64.tar.gz" \
+  && sudo mkdir /opt/gometalinter \
+  && curl -L $GOMETALINTER_URL | sudo tar --strip-components=1 -C /opt/gometalinter -xzf -
+COPY gometalinter.sh /etc/profile.d

--- a/.circleci/images/go.sh
+++ b/.circleci/images/go.sh
@@ -1,0 +1,2 @@
+export GOPATH="$HOME/go"
+export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH"

--- a/.circleci/images/gometalinter.sh
+++ b/.circleci/images/gometalinter.sh
@@ -1,0 +1,1 @@
+export PATH="/opt/gometalinter:$PATH"


### PR DESCRIPTION
This is version 3 of #49.

Changes from v2:
- Setup environment variables in /etc/profile.d, not ~/.profile in a container
- Use COPY statement to create /etc/profile.d/*.sh
- Place gometalinter with version-independent directory: /opt/gometalinter