### PR TITLE
CI: Update Go Meta Linter v2.0.12

### DIFF
--- a/.circleci/images/Dockerfile
+++ b/.circleci/images/Dockerfile
@@ -18,7 +18,7 @@ RUN SGX_SDK_URL="https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_l
   && rm -f /tmp/sgx_linux_x64_sdk.bin \
   && sudo ln -s /opt/intel/sgxsdk/environment /etc/profile.d/intel-sgxsdk.sh
 
-RUN GOMETALINTER_URL="https://github.com/alecthomas/gometalinter/releases/download/v2.0.11/gometalinter-2.0.11-linux-amd64.tar.gz" \
+RUN GOMETALINTER_URL="https://github.com/alecthomas/gometalinter/releases/download/v2.0.12/gometalinter-2.0.12-linux-amd64.tar.gz" \
   && sudo mkdir /opt/gometalinter \
   && curl -L $GOMETALINTER_URL | sudo tar --strip-components=1 -C /opt/gometalinter -xzf -
 COPY gometalinter.sh /etc/profile.d


### PR DESCRIPTION
Update gometalinter, which is used in the CI environment as a linter, to the latest release, v2.0.12.

This patch closes #51.