### PR TITLE
Sample replica connector tolerates f connection failure

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,7 +59,7 @@ func New(id uint32, n, f uint32, stack Stack) (Client, error) {
 
 	buf := requestbuffer.New()
 
-	if err := startReplicaConnections(id, n, buf, stack); err != nil {
+	if err := startReplicaConnections(id, n, f, buf, stack); err != nil {
 		return nil, fmt.Errorf("Failed to initiate connections to replicas: %s", err)
 	}
 

--- a/core/replica.go
+++ b/core/replica.go
@@ -44,6 +44,7 @@ var _ api.MessageStreamHandler = (*Replica)(nil)
 type Replica struct {
 	id uint32 // replica ID, unique in range [0,n)
 	n  uint32 // total number of nodes
+	f  uint32 // number of tolerable faulty nodes
 
 	stack Stack
 
@@ -65,6 +66,7 @@ func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (*Replic
 	replica := &Replica{
 		id: id,
 		n:  n,
+		f:  f,
 
 		stack: stack,
 
@@ -80,6 +82,7 @@ func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (*Replic
 
 // Start begins message exchange with peer replicas
 func (r *Replica) Start() error {
+	f := uint32(0)
 	for i := uint32(0); i < r.n; i++ {
 		if i == r.id {
 			continue
@@ -87,7 +90,13 @@ func (r *Replica) Start() error {
 		out := make(chan []byte)
 		sh, err := r.stack.ReplicaMessageStreamHandler(i)
 		if err != nil {
-			return fmt.Errorf("Error getting peer replica %d message stream handler: %s", i, err)
+			f += 1
+			if f <= r.f {
+				fmt.Printf("Error getting peer replica %d message stream handler: %s\n", i, err)
+				continue
+			} else {
+				return fmt.Errorf("Error getting connection failures from more than %d peer replicas", r.f)
+			}
 		}
 		// Reply stream is not used for replica-to-replica
 		// communication, thus return value is ignored. Each
@@ -96,7 +105,13 @@ func (r *Replica) Start() error {
 		// connected.
 		_, err = sh.HandleMessageStream(out)
 		if err != nil {
-			return fmt.Errorf("Error establishing connection to peer replica %d: %s", i, err)
+			f += 1
+			if f <= r.f {
+				fmt.Printf("Error establishing connection to peer replica %d: %s\n", i, err)
+				continue
+			} else {
+				return fmt.Errorf("Error getting connection failures from more than %d peer replicas", r.f)
+			}
 		}
 
 		go func() {

--- a/sample/net/grpc/connector/replica-connector.go
+++ b/sample/net/grpc/connector/replica-connector.go
@@ -77,14 +77,13 @@ func (c *ReplicaConnector) ConnectReplica(replicaID uint32, target string, dialO
 
 // ConnectManyReplicas establishes a connection to many replicas given
 // a map from a replica ID to its gRPC target (address).
-func (c *ReplicaConnector) ConnectManyReplicas(targets map[uint32]string, dialOpts ...grpc.DialOption) error {
+func (c *ReplicaConnector) ConnectManyReplicas(targets map[uint32]string, dialOpts ...grpc.DialOption) {
 	for id, target := range targets {
 		err := c.ConnectReplica(id, target, dialOpts...)
 		if err != nil {
-			return err
+			fmt.Printf("Faled to connect peer %d: %s\n", id, err)
 		}
 	}
-	return nil
 }
 
 // messageStramHandler is a local representation of the replica for

--- a/sample/net/grpc/grpc_test.go
+++ b/sample/net/grpc/grpc_test.go
@@ -42,13 +42,12 @@ func TestReplicaMessageStreamHandler(t *testing.T) {
 	defer stopLoopServers(servers)
 
 	replicaConnector := connector.New()
-	err := replicaConnector.ConnectManyReplicas(addrs, grpc.WithInsecure(), grpc.WithBlock())
-	require.NoError(t, err)
+	replicaConnector.ConnectManyReplicas(addrs, grpc.WithInsecure(), grpc.WithBlock())
 
 	inChannels := prepareInChannels(msgs)
 	outChannels := startMessageStreams(t, replicaConnector, inChannels)
 
-	_, err = replicaConnector.ReplicaMessageStreamHandler(nrReplicas)
+	_, err := replicaConnector.ReplicaMessageStreamHandler(nrReplicas)
 	assert.Error(t, err, "ReplicaMessageStreamHandler must fail with unassigned replica ID")
 
 	checkOutChannels(t, msgs, outChannels)

--- a/sample/peer/cmd/request.go
+++ b/sample/peer/cmd/request.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hyperledger-labs/minbft/api"
 	"github.com/hyperledger-labs/minbft/client"
@@ -90,7 +91,7 @@ func request(req []byte) ([]byte, error) {
 
 	rc := connector.New()
 
-	err = rc.ConnectManyReplicas(peerAddrs, grpc.WithInsecure(), grpc.WithBlock())
+	err = rc.ConnectManyReplicas(peerAddrs, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5 * time.Second))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to peers: %s", err)
 	}

--- a/sample/peer/cmd/request.go
+++ b/sample/peer/cmd/request.go
@@ -91,10 +91,7 @@ func request(req []byte) ([]byte, error) {
 
 	rc := connector.New()
 
-	err = rc.ConnectManyReplicas(peerAddrs, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5 * time.Second))
-	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to peers: %s", err)
-	}
+	rc.ConnectManyReplicas(peerAddrs, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5 * time.Second))
 
 	client, err := client.New(id, cfg.N(), cfg.F(), clientStack{auth, rc})
 	if err != nil {

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/a8m/envsubst"
 	logging "github.com/op/go-logging"
@@ -144,7 +145,7 @@ func run() error {
 	}()
 
 	delete(peerAddrs, id) // avoid connecting back to this replica
-	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()}
+	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5 * time.Second)}
 	if err := replicaConnector.ConnectManyReplicas(peerAddrs, dialOpts...); err != nil {
 		return fmt.Errorf("Failed to connect to peers: %s", err)
 	}

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -146,9 +146,7 @@ func run() error {
 
 	delete(peerAddrs, id) // avoid connecting back to this replica
 	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5 * time.Second)}
-	if err := replicaConnector.ConnectManyReplicas(peerAddrs, dialOpts...); err != nil {
-		return fmt.Errorf("Failed to connect to peers: %s", err)
-	}
+	replicaConnector.ConnectManyReplicas(peerAddrs, dialOpts...)
 
 	if err := replica.Start(); err != nil {
 		return fmt.Errorf("Failed to start replica: %s", err)


### PR DESCRIPTION
As stated in #1, current sample replica connector doesn't accept any connection failure to replicas, leading to whole system stall. This patchset tries to change this by making `peer-run`/`peer-request` commands fail to start when detecting more than `f` connection failure.