### PR TITLE
Sample replica connector tolerates f connection failures

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -59,7 +59,7 @@ func New(id uint32, n, f uint32, stack Stack) (Client, error) {
 
 	buf := requestbuffer.New()
 
-	if err := startReplicaConnections(id, n, buf, stack); err != nil {
+	if err := startReplicaConnections(id, n, f, buf, stack); err != nil {
 		return nil, fmt.Errorf("Failed to initiate connections to replicas: %s", err)
 	}
 

--- a/client/message-handling.go
+++ b/client/message-handling.go
@@ -30,17 +30,24 @@ import (
 // starts message exchange with them given a total number of replicas,
 // request buffer to add/fetch messages to/from and a stack of
 // interfaces to external modules.
-func startReplicaConnections(clientID, n uint32, buf *requestbuffer.T, stack Stack) error {
+func startReplicaConnections(clientID, n uint32, f uint32, buf *requestbuffer.T, stack Stack) error {
 	outHandler := makeOutgoingMessageHandler(buf)
 	authenticator := makeReplyAuthenticator(clientID, stack)
 	consumer := makeReplyConsumer(buf)
 	handleReply := makeReplyMessageHandler(consumer, authenticator)
 
+	faulty := uint32(0)
 	for i := uint32(0); i < n; i++ {
 		connector := makeReplicaConnector(i, stack)
 		inHandler := makeIncomingMessageHandler(i, handleReply)
 		if err := startReplicaConnection(outHandler, inHandler, connector); err != nil {
-			return fmt.Errorf("Error connecting to replica %d: %s", i, err)
+			faulty++
+			if faulty <= f {
+				fmt.Printf("Error connecting to replica %d: %s\n", i, err)
+				continue
+			} else {
+				return fmt.Errorf("Error getting connection failures from more than %d replicas", f)
+			}
 		}
 	}
 

--- a/sample/net/grpc/connector/replica-connector.go
+++ b/sample/net/grpc/connector/replica-connector.go
@@ -64,8 +64,8 @@ func (c *ReplicaConnector) SetReplicaClient(replicaID uint32, client proto.Chann
 
 // ConnectReplica establishes a connection to a replica by its gRPC
 // target (address).
-func (c *ReplicaConnector) ConnectReplica(replicaID uint32, target string, dialOpts ...grpc.DialOption) error {
-	connection, err := grpc.Dial(target, dialOpts...)
+func (c *ReplicaConnector) ConnectReplica(ctx context.Context, replicaID uint32, target string, dialOpts ...grpc.DialOption) error {
+	connection, err := grpc.DialContext(ctx, target, dialOpts...)
 	if err != nil {
 		return fmt.Errorf("Failed to dial replica: %s", err)
 	}
@@ -77,9 +77,9 @@ func (c *ReplicaConnector) ConnectReplica(replicaID uint32, target string, dialO
 
 // ConnectManyReplicas establishes a connection to many replicas given
 // a map from a replica ID to its gRPC target (address).
-func (c *ReplicaConnector) ConnectManyReplicas(targets map[uint32]string, dialOpts ...grpc.DialOption) error {
+func (c *ReplicaConnector) ConnectManyReplicas(ctx context.Context, targets map[uint32]string, dialOpts ...grpc.DialOption) error {
 	for id, target := range targets {
-		err := c.ConnectReplica(id, target, dialOpts...)
+		err := c.ConnectReplica(ctx, id, target, dialOpts...)
 		if err != nil {
 			return err
 		}

--- a/sample/net/grpc/connector/replica-connector.go
+++ b/sample/net/grpc/connector/replica-connector.go
@@ -77,14 +77,13 @@ func (c *ReplicaConnector) ConnectReplica(ctx context.Context, replicaID uint32,
 
 // ConnectManyReplicas establishes a connection to many replicas given
 // a map from a replica ID to its gRPC target (address).
-func (c *ReplicaConnector) ConnectManyReplicas(ctx context.Context, targets map[uint32]string, dialOpts ...grpc.DialOption) error {
+func (c *ReplicaConnector) ConnectManyReplicas(ctx context.Context, targets map[uint32]string, dialOpts ...grpc.DialOption) {
 	for id, target := range targets {
 		err := c.ConnectReplica(ctx, id, target, dialOpts...)
 		if err != nil {
-			return err
+			fmt.Printf("Faled to connect peer %d: %s\n", id, err)
 		}
 	}
-	return nil
 }
 
 // messageStramHandler is a local representation of the replica for

--- a/sample/net/grpc/grpc_test.go
+++ b/sample/net/grpc/grpc_test.go
@@ -43,13 +43,12 @@ func TestReplicaMessageStreamHandler(t *testing.T) {
 	defer stopLoopServers(servers)
 
 	replicaConnector := connector.New()
-	err := replicaConnector.ConnectManyReplicas(context.Background(), addrs, grpc.WithInsecure(), grpc.WithBlock())
-	require.NoError(t, err)
+	replicaConnector.ConnectManyReplicas(context.Background(), addrs, grpc.WithInsecure(), grpc.WithBlock())
 
 	inChannels := prepareInChannels(msgs)
 	outChannels := startMessageStreams(t, replicaConnector, inChannels)
 
-	_, err = replicaConnector.ReplicaMessageStreamHandler(nrReplicas)
+	_, err := replicaConnector.ReplicaMessageStreamHandler(nrReplicas)
 	assert.Error(t, err, "ReplicaMessageStreamHandler must fail with unassigned replica ID")
 
 	checkOutChannels(t, msgs, outChannels)

--- a/sample/net/grpc/grpc_test.go
+++ b/sample/net/grpc/grpc_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/hyperledger-labs/minbft/sample/net/grpc/connector"
@@ -42,7 +43,7 @@ func TestReplicaMessageStreamHandler(t *testing.T) {
 	defer stopLoopServers(servers)
 
 	replicaConnector := connector.New()
-	err := replicaConnector.ConnectManyReplicas(addrs, grpc.WithInsecure(), grpc.WithBlock())
+	err := replicaConnector.ConnectManyReplicas(context.Background(), addrs, grpc.WithInsecure(), grpc.WithBlock())
 	require.NoError(t, err)
 
 	inChannels := prepareInChannels(msgs)
@@ -61,7 +62,7 @@ func TestReplicaServer(t *testing.T) {
 
 	msgs := makeTestMessages(1, nrMessages)
 	replicaConnector := connector.New()
-	err := replicaConnector.ConnectReplica(uint32(0), addr, grpc.WithInsecure(), grpc.WithBlock())
+	err := replicaConnector.ConnectReplica(context.Background(), uint32(0), addr, grpc.WithInsecure(), grpc.WithBlock())
 	require.NoError(t, err)
 
 	inChannels := prepareInChannels(msgs)

--- a/sample/peer/cmd/request.go
+++ b/sample/peer/cmd/request.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hyperledger-labs/minbft/api"
 	"github.com/hyperledger-labs/minbft/client"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 
@@ -90,7 +92,9 @@ func request(req []byte) ([]byte, error) {
 
 	rc := connector.New()
 
-	err = rc.ConnectManyReplicas(peerAddrs, grpc.WithInsecure(), grpc.WithBlock())
+	ctx := context.Background()
+	ctx, _ = context.WithTimeout(ctx, 5*time.Second)
+	err = rc.ConnectManyReplicas(ctx, peerAddrs, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to peers: %s", err)
 	}

--- a/sample/peer/cmd/request.go
+++ b/sample/peer/cmd/request.go
@@ -94,10 +94,7 @@ func request(req []byte) ([]byte, error) {
 
 	ctx := context.Background()
 	ctx, _ = context.WithTimeout(ctx, 5*time.Second)
-	err = rc.ConnectManyReplicas(ctx, peerAddrs, grpc.WithInsecure(), grpc.WithBlock())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to peers: %s", err)
-	}
+	rc.ConnectManyReplicas(ctx, peerAddrs, grpc.WithInsecure(), grpc.WithBlock())
 
 	client, err := client.New(id, cfg.N(), cfg.F(), clientStack{auth, rc})
 	if err != nil {

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -149,9 +149,7 @@ func run() error {
 	ctx := context.Background()
 	ctx, _ = context.WithTimeout(ctx, 5*time.Second)
 	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()}
-	if err := replicaConnector.ConnectManyReplicas(ctx, peerAddrs, dialOpts...); err != nil {
-		return fmt.Errorf("Failed to connect to peers: %s", err)
-	}
+	replicaConnector.ConnectManyReplicas(ctx, peerAddrs, dialOpts...)
 
 	if err := replica.Start(); err != nil {
 		return fmt.Errorf("Failed to start replica: %s", err)

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/a8m/envsubst"
 	logging "github.com/op/go-logging"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/hyperledger-labs/minbft/api"
@@ -144,8 +146,10 @@ func run() error {
 	}()
 
 	delete(peerAddrs, id) // avoid connecting back to this replica
+	ctx := context.Background()
+	ctx, _ = context.WithTimeout(ctx, 5*time.Second)
 	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()}
-	if err := replicaConnector.ConnectManyReplicas(peerAddrs, dialOpts...); err != nil {
+	if err := replicaConnector.ConnectManyReplicas(ctx, peerAddrs, dialOpts...); err != nil {
 		return fmt.Errorf("Failed to connect to peers: %s", err)
 	}
 


### PR DESCRIPTION
As stated in #1, current sample replica connector doesn't accept any connection failure to replicas, leading to whole system stall. This patchset tries to change this by making peer-run/peer-request commands fail to start when detecting more than `f` connection failure.

I updated some from #67 to fix test failures and gometalinter failures.

