### PR TITLE
Sample replica connector tolerates f connection failures (v2)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -66,7 +66,7 @@ type ReplicaConnector interface {
 // any of the channels, it is the receiver's responsibility to finish
 // handling of the message.
 type MessageStreamHandler interface {
-	HandleMessageStream(in <-chan []byte) (out <-chan []byte, err error)
+	HandleMessageStream(in <-chan []byte) (out <-chan []byte)
 }
 
 //======= Interface for module 'authentication' ========

--- a/api/api.go
+++ b/api/api.go
@@ -53,6 +53,8 @@ type Configer interface {
 // guarantees reliable and secure message delivery to the replica.
 // Message delivery delay is assumed not to grow indefinitely. This
 // assumption has to be satisfied to ensure the liveness of the system.
+// ReplicaMessageStreamHandler never fails except when incorrect replica
+// ID is passed.
 type ReplicaConnector interface {
 	ReplicaMessageStreamHandler(replicaID uint32) (MessageStreamHandler, error)
 }
@@ -64,7 +66,9 @@ type ReplicaConnector interface {
 // produced in reply. Each value sent/received through a channel is a
 // single complete serialized message. Once a message is received from
 // any of the channels, it is the receiver's responsibility to finish
-// handling of the message.
+// handling of the message. Another note is that the remote replica
+// might be unreachable, and in order to avoid whole system being stuck,
+// you should also initialize message stream asynchronously in goroutine.
 type MessageStreamHandler interface {
 	HandleMessageStream(in <-chan []byte) (out <-chan []byte)
 }

--- a/client/message-handling.go
+++ b/client/message-handling.go
@@ -119,7 +119,7 @@ func makeReplicaConnector(replicaID uint32, connector api.ReplicaConnector) repl
 		if err != nil {
 			return nil, fmt.Errorf("Error getting message stream handler: %s", err)
 		}
-		in, err := streamHandler.HandleMessageStream(out)
+		in := streamHandler.HandleMessageStream(out)
 		if err != nil {
 			return nil, fmt.Errorf("Error establishing connection: %s", err)
 		}

--- a/core/replica.go
+++ b/core/replica.go
@@ -94,10 +94,7 @@ func (r *Replica) Start() error {
 		// replica will establish connections to other peers
 		// the same way, so they all will be eventually fully
 		// connected.
-		_, err = sh.HandleMessageStream(out)
-		if err != nil {
-			return fmt.Errorf("Error establishing connection to peer replica %d: %s", i, err)
-		}
+		sh.HandleMessageStream(out)
 
 		go func() {
 			for msg := range r.log.Stream(nil) {
@@ -114,10 +111,10 @@ func (r *Replica) Start() error {
 
 // HandleMessageStream initiates handling of incoming messages and
 // supplies reply messages back, if any.
-func (r *Replica) HandleMessageStream(in <-chan []byte) (<-chan []byte, error) {
+func (r *Replica) HandleMessageStream(in <-chan []byte) <-chan []byte {
 	out := make(chan []byte)
 
 	go r.handleStream(in, out)
 
-	return out, nil
+	return out
 }

--- a/sample/net/grpc/connector/replica-connector.go
+++ b/sample/net/grpc/connector/replica-connector.go
@@ -97,7 +97,7 @@ type messageStreamHandler struct {
 
 // HandleMessageStream implements actual communication with remote
 // replica by means of the gRPC connection established to the replica.
-func (h *messageStreamHandler) HandleMessageStream(in <-chan []byte) (<-chan []byte, error) {
+func (h *messageStreamHandler) HandleMessageStream(in <-chan []byte) <-chan []byte {
 	var stream proto.Channel_ChatClient
 	var wg sync.WaitGroup
 	out := make(chan []byte)
@@ -147,5 +147,5 @@ func (h *messageStreamHandler) HandleMessageStream(in <-chan []byte) (<-chan []b
 		}
 	}()
 
-	return out, nil
+	return out
 }

--- a/sample/net/grpc/grpc_test.go
+++ b/sample/net/grpc/grpc_test.go
@@ -42,7 +42,7 @@ func TestReplicaMessageStreamHandler(t *testing.T) {
 	defer stopLoopServers(servers)
 
 	replicaConnector := connector.New()
-	err := replicaConnector.ConnectManyReplicas(addrs, grpc.WithInsecure(), grpc.WithBlock())
+	err := replicaConnector.ConnectManyReplicas(addrs, grpc.WithInsecure())
 	require.NoError(t, err)
 
 	inChannels := prepareInChannels(msgs)

--- a/sample/net/grpc/grpc_test.go
+++ b/sample/net/grpc/grpc_test.go
@@ -113,8 +113,7 @@ func startMessageStreams(t *testing.T, replicaConnector *connector.ReplicaConnec
 		require.NoError(t, err)
 		require.NotNil(t, streamHandler)
 
-		out, err := streamHandler.HandleMessageStream(in)
-		require.NoError(t, err)
+		out := streamHandler.HandleMessageStream(in)
 		require.NotNil(t, out)
 		outChannels[i] = out
 	}
@@ -172,7 +171,7 @@ type loopReplica struct {
 	grpcServer *grpc.Server
 }
 
-func (r *loopReplica) HandleMessageStream(in <-chan []byte) (<-chan []byte, error) {
+func (r *loopReplica) HandleMessageStream(in <-chan []byte) <-chan []byte {
 	// Buffer a couple of messages to create a bit of concurrency
 	out := make(chan []byte, 2)
 	go func() {
@@ -181,7 +180,7 @@ func (r *loopReplica) HandleMessageStream(in <-chan []byte) (<-chan []byte, erro
 		}
 		close(out)
 	}()
-	return out, nil
+	return out
 }
 
 func (r *loopReplica) start() (addr string) {

--- a/sample/net/grpc/server/replica-server.go
+++ b/sample/net/grpc/server/replica-server.go
@@ -77,10 +77,7 @@ func (s *ReplicaServer) Stop() {
 // Chat implements a corresponding gRPC server interface method
 func (s *ReplicaServer) Chat(stream proto.Channel_ChatServer) error {
 	in := make(chan []byte)
-	out, err := s.replica.HandleMessageStream(in)
-	if err != nil {
-		return err
-	}
+	out := s.replica.HandleMessageStream(in)
 
 	eg := new(errgroup.Group)
 

--- a/sample/peer/cmd/request.go
+++ b/sample/peer/cmd/request.go
@@ -90,7 +90,7 @@ func request(req []byte) ([]byte, error) {
 
 	rc := connector.New()
 
-	err = rc.ConnectManyReplicas(peerAddrs, grpc.WithInsecure(), grpc.WithBlock())
+	err = rc.ConnectManyReplicas(peerAddrs, grpc.WithInsecure())
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to peers: %s", err)
 	}

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -144,8 +144,7 @@ func run() error {
 	}()
 
 	delete(peerAddrs, id) // avoid connecting back to this replica
-	dialOpts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()}
-	if err := replicaConnector.ConnectManyReplicas(peerAddrs, dialOpts...); err != nil {
+	if err := replicaConnector.ConnectManyReplicas(peerAddrs, grpc.WithInsecure()); err != nil {
 		return fmt.Errorf("Failed to connect to peers: %s", err)
 	}
 


### PR DESCRIPTION
This PR is v2 of #68, but with quite different approach:
- by removing `grpc.WithBlock()` option, which makes `ConnectManyReplicas()` never fail
- by calling `ChannelClient#Chat()` with `grpc.FailFast(false)` *and* in goroutine, the main thread never gets stuck on connection failures. 

We still can't handle the cases like below:
- when the primary replica is unreachable,
- when some replica becomes unreachable after it once booted up properly.

These will be future works.