### PR TITLE
Enable GitHub Checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,3 +39,8 @@ jobs:
           name: Lint
           command: |
             make lint
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build


### PR DESCRIPTION
As described in #65, CircleCI is not triggered occasionally.
According to [the official document](https://circleci.com/docs/2.0/enable-checks/), we need to use "Workflows" in the configuration to enable GitHub Checks. This patch updates the configuration to use the feature.