### PR TITLE
Remove nolint from core/usig/sgx/usig-enclave.go.in

### DIFF
--- a/usig/sgx/usig-enclave.go.in
+++ b/usig/sgx/usig-enclave.go.in
@@ -64,9 +64,7 @@ func NewUSIGEnclave(enclaveFile string, sealedKey []byte) (*USIGEnclave, error) 
 	sealedDataSize := C.size_t(len(sealedKey))
 	var sealedData unsafe.Pointer
 	if len(sealedKey) != 0 {
-		// vet linter reports an error, but it's been recently fixed.
-		// So disable linting until gometalinter picks up this update
-		sealedData = C.CBytes(sealedKey) // nolint: vet
+		sealedData = C.CBytes(sealedKey)
 		defer C.free(sealedData)
 	}
 


### PR DESCRIPTION
This `nolint` was workaround for an inssue of a linter (see #4).
Now the issue is fixed, we should remove the comment.

This closes #4.
