### PR TITLE
Remove Dependency on GOPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *~
-bin
+/sample/build/

--- a/README.md
+++ b/README.md
@@ -117,13 +117,7 @@ sudo apt-get install build-essential pkg-config
 ### Golang ###
 
 `go1.11` is used to build this project. For installation instructions
-please visit [this page](https://golang.org/doc/install). Please make
-sure to export `GOPATH` environment variable, e.g. by adding the
-following line to `~/.profile`:
-
-```sh
-export GOPATH="$HOME/go"
-```
+please visit [this page](https://golang.org/doc/install).
 
 ### Intel® SGX SDK ###
 
@@ -166,13 +160,13 @@ module's source tree.
 
 ### Building ###
 
-The project can be build by issuing the following command:
+The project can be build by issuing the following command. At the
+moment, the binaries are installed in `sample/bin/` directory; no root
+privileges are needed.
 
 ```sh
-make build
+make install
 ```
-
-The binaries produced are placed under `sample/bin/` directory.
 
 ### Running Example ###
 
@@ -185,10 +179,6 @@ options can be queried by invoking those binaries with `help`
 argument. Sample configuration files can be found in
 `sample/authentication/keytool/` and `sample/peer/` directories
 respectively.
-
-If this is placed outside GOPATH, a path of a USIG enclave file must be
-passed to the commands (e.g. `-u ../usig/sgx/enclave/libusig.signed.so`
-command line arguments).
 
 #### Generating Keys ####
 
@@ -203,7 +193,7 @@ command. This command produces a key set file suitable for running the
 example on a local machine:
 
 ```sh
-bin/keytool generate
+bin/keytool generate -u lib/libusig.signed.so
 ```
 
 This invocation will create a sample key set file named `keys.yaml`

--- a/sample/authentication/keytool/cmd/generate.go
+++ b/sample/authentication/keytool/cmd/generate.go
@@ -37,8 +37,7 @@ const (
 	defClientKeySpec   = "ECDSA"
 	defClientSecParam  = 256
 
-	defUsigEnclaveFile = "$GOPATH/src/github.com/hyperledger-labs/minbft/" +
-		"usig/sgx/enclave/libusig.signed.so"
+	defUsigEnclaveFile = "libusig.signed.so"
 )
 
 // generateCmd represents the generate command

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -39,8 +39,7 @@ import (
 const (
 	defConsensusCfgFile = "consensus.yaml"
 	defKeysFile         = "keys.yaml"
-	defUsigEnclaveFile  = "$GOPATH/src/github.com/hyperledger-labs/minbft/" +
-		"usig/sgx/enclave/libusig.signed.so"
+	defUsigEnclaveFile  = "libusig.signed.so"
 )
 
 // runCmd represents the run command

--- a/sample/peer/peer.yaml
+++ b/sample/peer/peer.yaml
@@ -19,4 +19,4 @@ client:
 # USIG options
 usig:
   # USIG enclave file (environment expansion is supported)
-  enclaveFile: "$GOPATH/src/github.com/hyperledger-labs/minbft/usig/sgx/enclave/libusig.signed.so"
+  enclaveFile: "lib/libusig.signed.so"


### PR DESCRIPTION
`keytool` and `peer` commands load libusig.signed.so from `$GOPATH/src/github.com/hyperledger-labs/minbft/usig/sgx/enclave` by default. Since we are now a Go module and independent from GOPATH, we should rethink this default value.

This patch updates the default path to find the library from a current directory. This patch also update Makefile to add `install` target to install the commands and the library into a single directory (by default, `sample/bin` and `sample/lib` respectively), and sample configuration files to try this project with minimal configuration wherever this project is placed on a file system.

Note: variables in the Makefile are defined based on [Makefile conventions](https://www.gnu.org/software/make/manual/html_node/Makefile-Conventions.html#Makefile-Conventions) with some simplification.

This closes #86.