### PR TITLE
Remove Dependency on GOPATH (V2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *~
-bin
+/sample/build/
+
+# Default installation directories
+/sample/bin/
+/sample/lib/

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all build clean check test lint generate
+INSTALL := install
+INSTALL_PROGRAM := $(INSTALL)
+INSTALL_DATA := $(INSTALL) -m 644
+
+builddir := sample/build
+
+prefix ?= sample
+bindir := $(prefix)/bin
+libdir := $(prefix)/lib
+
+.PHONY: all build install uninstall clean check test lint generate
 
 all: build check
 test: check
@@ -31,6 +41,8 @@ help:
 	@echo 'Generic targets:'
 	@echo '  all (default)    - Build and test all'
 	@echo '  build            - Build all'
+	@echo '  install          - Install artifacts'
+	@echo '  uninstall        - Uninstall artifacts'
 	@echo '  clean            - Remove all build artifacts'
 	@echo '  check|test       - Run all tests'
 	@echo '  lint             - Run code quality checks'
@@ -40,12 +52,22 @@ help:
 	@echo '  usig-*           - Make USIG target, where target is one of:'
 	@echo '                     $(usig-target-list)'
 
-build: usig-build | bin
-	go build -o sample/bin/peer ./sample/peer
-	go build -o sample/bin/keytool ./sample/authentication/keytool
+build: usig-build
+	go build -o $(builddir)/keytool ./sample/authentication/keytool
+	go build -o $(builddir)/peer ./sample/peer
+
+install: build
+	$(INSTALL_PROGRAM) -D $(builddir)/keytool $(bindir)/keytool
+	$(INSTALL_PROGRAM) -D $(builddir)/peer $(bindir)/peer
+	$(INSTALL_DATA) -D usig/sgx/enclave/libusig.signed.so $(libdir)/libusig.signed.so
+
+uninstall:
+	rm -f $(bindir)/keytool
+	rm -f $(bindir)/peer
+	rm -f $(libdir)/libusig.signed.so
 
 clean: usig-clean
-	rm -rf bin
+	rm -rf $(builddir)
 
 check: usig-build usig-check
 	go test -short -race ./...
@@ -58,6 +80,3 @@ generate:
 
 $(usig-target-list):
 	$(MAKE) -C usig/sgx $(patsubst usig-%,%,$@)
-
-bin:
-	@mkdir -p bin

--- a/README.md
+++ b/README.md
@@ -117,13 +117,7 @@ sudo apt-get install build-essential pkg-config
 ### Golang ###
 
 `go1.11` is used to build this project. For installation instructions
-please visit [this page](https://golang.org/doc/install). Please make
-sure to export `GOPATH` environment variable, e.g. by adding the
-following line to `~/.profile`:
-
-```sh
-export GOPATH="$HOME/go"
-```
+please visit [this page](https://golang.org/doc/install).
 
 ### Intel® SGX SDK ###
 
@@ -166,13 +160,13 @@ module's source tree.
 
 ### Building ###
 
-The project can be build by issuing the following command:
+The project can be build by issuing the following command. At the
+moment, the binaries are installed in `sample/bin/` directory; no root
+privileges are needed.
 
 ```sh
-make build
+make install
 ```
-
-The binaries produced are placed under `sample/bin/` directory.
 
 ### Running Example ###
 
@@ -185,10 +179,6 @@ options can be queried by invoking those binaries with `help`
 argument. Sample configuration files can be found in
 `sample/authentication/keytool/` and `sample/peer/` directories
 respectively.
-
-If this is placed outside GOPATH, a path of a USIG enclave file must be
-passed to the commands (e.g. `-u ../usig/sgx/enclave/libusig.signed.so`
-command line arguments).
 
 #### Generating Keys ####
 
@@ -203,7 +193,7 @@ command. This command produces a key set file suitable for running the
 example on a local machine:
 
 ```sh
-bin/keytool generate
+bin/keytool generate -u lib/libusig.signed.so
 ```
 
 This invocation will create a sample key set file named `keys.yaml`

--- a/sample/authentication/keytool/cmd/generate.go
+++ b/sample/authentication/keytool/cmd/generate.go
@@ -37,8 +37,7 @@ const (
 	defClientKeySpec   = "ECDSA"
 	defClientSecParam  = 256
 
-	defUsigEnclaveFile = "$GOPATH/src/github.com/hyperledger-labs/minbft/" +
-		"usig/sgx/enclave/libusig.signed.so"
+	defUsigEnclaveFile = "libusig.signed.so"
 )
 
 // generateCmd represents the generate command

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -39,8 +39,7 @@ import (
 const (
 	defConsensusCfgFile = "consensus.yaml"
 	defKeysFile         = "keys.yaml"
-	defUsigEnclaveFile  = "$GOPATH/src/github.com/hyperledger-labs/minbft/" +
-		"usig/sgx/enclave/libusig.signed.so"
+	defUsigEnclaveFile  = "libusig.signed.so"
 )
 
 // runCmd represents the run command

--- a/sample/peer/peer.yaml
+++ b/sample/peer/peer.yaml
@@ -19,4 +19,4 @@ client:
 # USIG options
 usig:
   # USIG enclave file (environment expansion is supported)
-  enclaveFile: "$GOPATH/src/github.com/hyperledger-labs/minbft/usig/sgx/enclave/libusig.signed.so"
+  enclaveFile: "lib/libusig.signed.so"


### PR DESCRIPTION
This is version 2 of #88.

Changes from the previous version:

- Add the default installation directories to `.gitignore`
- Use `install -D` to install binaries with making target directories
- Now a user can change an installation directory with `make prefix=<dir>`