### PR TITLE
Makefile: Fix Help Message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ help:
 	@echo 'Generic targets:'
 	@echo '  all (default)    - Build and test all'
 	@echo '  build            - Build all'
-	@echo '  install          - Install artifacts'
+	@echo '  install          - Build and install artifacts'
 	@echo '  uninstall        - Uninstall artifacts'
 	@echo '  clean            - Remove all build artifacts'
 	@echo '  check|test       - Run all tests'


### PR DESCRIPTION
As pointed out in https://github.com/hyperledger-labs/minbft/pull/89#discussion_r282391792, `make install` do not only install but also build. This patch updates the help message to describe the target includes the build process.