### PR TITLE
Start request timer in primary

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -156,8 +156,13 @@ func makeRequestApplier(id, n uint32, view viewProvider, handleGeneratedUIMessag
 		view := view()
 		primary := isPrimary(view, id, n)
 
-		// TODO: A new Request has arrived; the request timer
-		// should be re-/started at this point.
+		// The primary has to start request timer, as well.
+		// Suppose, the primary is correct, but its messages
+		// are delayed, and other replicas switch to a new
+		// view. In that case, other replicas might rely on
+		// this correct replica to trigger another view
+		// change, should the new primary be faulty.
+		startReqTimer(request.Msg.ClientId, view)
 
 		if primary {
 			prepare := &messages.Prepare{
@@ -169,8 +174,6 @@ func makeRequestApplier(id, n uint32, view viewProvider, handleGeneratedUIMessag
 			}
 
 			handleGeneratedUIMessage(prepare)
-		} else {
-			startReqTimer(request.Msg.ClientId, view)
 		}
 
 		return nil

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -119,6 +119,7 @@ func TestMakeRequestApplier(t *testing.T) {
 	assert.NoError(t, err)
 
 	mock.On("viewProvider").Return(ownView).Once()
+	mock.On("requestTimerStarter", clientID, ownView).Once()
 	mock.On("generatedUIMessageHandler", prepare).Once()
 	err = apply(request)
 	assert.NoError(t, err)


### PR DESCRIPTION
Even though any replica can always assume itself to be correct, a primary cannot safely assume its view to continue arbitrary long. Thus, it also needs to trigger view change in case some request times
out in its view.