### PR TITLE
Fix Memory Leak

### DIFF
--- a/usig/sgx/usig-enclave.go.in
+++ b/usig/sgx/usig-enclave.go.in
@@ -68,8 +68,10 @@ func NewUSIGEnclave(enclaveFile string, sealedKey []byte) (*USIGEnclave, error) 
 		defer C.free(sealedData)
 	}
 
+	file := C.CString(enclaveFile)
+	defer C.free(unsafe.Pointer(file))
 	sgxErr := C.usig_init(
-		C.CString(enclaveFile), &enclave.enclaveID,
+		file, &enclave.enclaveID,
 		sealedData, sealedDataSize,
 	)
 	if err := sgxError(sgxErr); err != nil {


### PR DESCRIPTION
C.CString(), which convert a Go string to a C string, allocates the C string in the C heap. We have to free it.

https://github.com/golang/go/wiki/cgo#go-strings-and-c-strings

> One important thing to remember is that C.CString() will allocate a new string of the appropriate length, and return it. That means the C string is not going to be garbage collected and it is up to you to free it. A standard way to do this follows.
