### PR TITLE
Detect skipped Commit messages

### DIFF
--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -219,6 +219,24 @@ func TestMakeCommitmentCounter(t *testing.T) {
 			replicaID: 2,
 			ok:        true,
 			done:      true,
+		}, {
+			desc:      "Second commitment from primary",
+			prepareCV: 2,
+			replicaID: 0,
+			ok:        true,
+			done:      false,
+		}, {
+			desc:      "Third commitment from primary",
+			prepareCV: 3,
+			replicaID: 0,
+			ok:        true,
+			done:      false,
+		}, {
+			desc:      "Non-sequential commitment from backup replica",
+			prepareCV: 3,
+			replicaID: 2,
+			ok:        false,
+			done:      false,
 		}},
 
 		// f=2


### PR DESCRIPTION
Correct replicas must always generate their Commit messages
sequentially, as they process Prepare messages from the primary.
However, Byzantine replicas might deviate from this behavior and do
not generate Commit messages for some Prepare messages. Current
implementation does not properly detect this.

Due to asynchronous nature of communication, different replicas might
collect different quorums of Prepare/Commit messages, including those
generated by faulty replicas. Thus, in current implementation, some
correct replicas might happen to erroneously skip some prepared
requests following Byzantine replicas. Fix this problem by detecting
and discarding such inconsistently generated Commit messages.