### PR TITLE
CI with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: Continuous integration
+on: push
+env:
+  SGX_SDK_URL: https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin
+  GOLANGCI_LINT_URL: https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+  GOLANGCI_LINT_VERSION: v1.21.0
+  SGX_MODE: SIM
+
+jobs:
+  build:
+    name: Continuous integration
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install Intel SGX SDK
+        run: |
+          curl -s $SGX_SDK_URL -o sgx_linux_x64_sdk.bin
+          chmod +x sgx_linux_x64_sdk.bin
+          echo -e "no\n/opt/intel" | sudo ./sgx_linux_x64_sdk.bin
+          rm sgx_linux_x64_sdk.bin
+      - name: Install GolangCI-Lint
+        run: |
+          curl -sfL $GOLANGCI_LINT_URL | sudo sh -s -- -b /usr/local/bin $GOLANGCI_LINT_VERSION
+      - uses: actions/checkout@v1
+      - name: Test
+        run: |
+          source /opt/intel/sgxsdk/environment
+          LD_LIBRARY_PATH="$PWD/usig/sgx/shim:$LD_LIBRARY_PATH" \
+          make build check
+      - name: Lint
+        run: |
+          make lint


### PR DESCRIPTION
[GitHub Actions](https://help.github.com/en/actions) is now available and now we have another alternative for CI.

This pull request activates CI with GitHub Actions. We will try this GitHub Actions in addition to the current CircleCI for some weeks then decide which one to use.

At this time, I prefer GitHub Actions:
- Set up: GitHub Action has already integrated, nothing to do. CircleCI needs some processes to integrate the service to GitHub. I spent much time to this part for the initial setup and the trouble shooting (the trigger worked only for me). Note that we don't have Admin privilege, so we need to request assistance to the LF team in some case.
- Configuration: There are small difference, but both are easy to write.
- Environment: GitHub Actions provides a VM while CircleCI provides a container to run CI. I don't find any good/bad effects from this difference.

This PR resolves #128.