### PR TITLE
peer/cmd/request: Introduce request timeout option

### DIFF
--- a/sample/peer/peer.yaml
+++ b/sample/peer/peer.yaml
@@ -16,6 +16,9 @@ client:
   # ID of the client instance
   id: 0
 
+  # Client request timeout (default: 0s, i.e. never timeout)
+  timeout: 3s
+
 # USIG options
 usig:
   # USIG enclave file (environment expansion is supported)


### PR DESCRIPTION
This pull request is separated from #127 for client request timeout part as recommended in [comment](https://github.com/hyperledger-labs/minbft/pull/127#pullrequestreview-322880648).