### PR TITLE
Fix prepare/request timers

### DIFF
--- a/core/commit.go
+++ b/core/commit.go
@@ -116,7 +116,7 @@ func makeCommitmentCollector(countCommitment commitmentCounter, retireSeq reques
 		}
 
 		pendingReq.Remove(request.Msg.ClientId)
-		stopReqTimer(request.Msg.ClientId)
+		stopReqTimer(request)
 		executeRequest(request)
 
 		return nil

--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -154,8 +154,8 @@ func TestMakeCommitmentCollector(t *testing.T) {
 		args := mock.MethodCalled("requestSeqRetirer", request)
 		return args.Bool(0)
 	}
-	stopReqTimer := func(clientID uint32) {
-		mock.MethodCalled("requestTimerStopper", clientID)
+	stopReqTimer := func(request *messages.Request) {
+		mock.MethodCalled("requestTimerStopper", request)
 	}
 	executeRequest := func(request *messages.Request) {
 		mock.MethodCalled("requestExecutor", request)
@@ -197,7 +197,7 @@ func TestMakeCommitmentCollector(t *testing.T) {
 	mock.On("commitmentCounter", id, prepare).Return(true, nil).Once()
 	mock.On("requestSeqRetirer", request).Return(true).Once()
 	pendingReq.EXPECT().Remove(clientID)
-	mock.On("requestTimerStopper", clientID).Once()
+	mock.On("requestTimerStopper", request).Once()
 	mock.On("requestExecutor", request).Once()
 	err = collect(id, prepare)
 	assert.NoError(t, err)

--- a/core/internal/clientstate/client-state.go
+++ b/core/internal/clientstate/client-state.go
@@ -87,19 +87,25 @@ func NewProvider(requestTimeout func() time.Duration, prepareTimeout func() time
 // there will be no Reply message to be added for the supplied request
 // identifier.
 //
-// StartRequestTimer starts a timer to expire after the duration of
-// request timeout. The supplied callback function handleTimeout is
-// invoked asynchronously upon timer expiration. If the previous timer
-// has not yet expired, it will be canceled and a new timer started.
+// StartRequestTimer starts a timer for the supplied request
+// identifier to expire after the duration of request timeout. The
+// supplied callback function handleTimeout is invoked asynchronously
+// upon timer expiration. If the previous timer started for any
+// request identifier has not yet expired, it will be canceled and a
+// new timer started.
 //
-// StopRequestTimer stops timer started by StartRequestTimer, if any.
+// StopRequestTimer stops timer started for the same request
+// identifier by StartRequestTimer, if any.
 //
-// StartPrepareTimer starts a timer to expire after the duration of
-// prepare timeout. The supplied callback function handleTimeout is
-// invoked asynchronously upon timer expiration. If the previous timer
-// has not yet expired, it will be canceled and a new timer started.
+// StartPrepareTimer starts a timer for the supplied request
+// identifier to expire after the duration of prepare timeout. The
+// supplied callback function handleTimeout is invoked asynchronously
+// upon timer expiration. If the previous timer started for any
+// request identifier has not yet expired, it will be canceled and a
+// new timer started.
 //
-// StopPrepareTimer stops timer started by StartPrepareTimer, if any.
+// StopPrepareTimer stops timer started for the same request
+// identifier by StartPrepareTimer, if any.
 type State interface {
 	CaptureRequestSeq(seq uint64) (new bool, release func())
 	PrepareRequestSeq(seq uint64) (new bool, err error)
@@ -108,11 +114,11 @@ type State interface {
 	AddReply(reply *messages.Reply) error
 	ReplyChannel(seq uint64) <-chan *messages.Reply
 
-	StartRequestTimer(handleTimeout func())
-	StopRequestTimer()
+	StartRequestTimer(seq uint64, handleTimeout func())
+	StopRequestTimer(seq uint64)
 
-	StartPrepareTimer(handleTimeout func())
-	StopPrepareTimer()
+	StartPrepareTimer(seq uint64, handleTimeout func())
+	StopPrepareTimer(seq uint64)
 }
 
 // New creates a new instance of client state representation. Optional
@@ -161,18 +167,18 @@ type clientState struct {
 	opts options
 }
 
-func (s *clientState) StartRequestTimer(handleTimeout func()) {
-	s.requestTimer.StartTimer(handleTimeout)
+func (s *clientState) StartRequestTimer(seq uint64, handleTimeout func()) {
+	s.requestTimer.StartTimer(seq, handleTimeout)
 }
 
-func (s *clientState) StopRequestTimer() {
-	s.requestTimer.StopTimer()
+func (s *clientState) StopRequestTimer(seq uint64) {
+	s.requestTimer.StopTimer(seq)
 }
 
-func (s *clientState) StartPrepareTimer(handleTimeout func()) {
-	s.prepareTimer.StartTimer(handleTimeout)
+func (s *clientState) StartPrepareTimer(seq uint64, handleTimeout func()) {
+	s.prepareTimer.StartTimer(seq, handleTimeout)
 }
 
-func (s *clientState) StopPrepareTimer() {
-	s.prepareTimer.StopTimer()
+func (s *clientState) StopPrepareTimer(seq uint64) {
+	s.prepareTimer.StopTimer(seq)
 }

--- a/core/internal/clientstate/mocks/mock.go
+++ b/core/internal/clientstate/mocks/mock.go
@@ -107,49 +107,49 @@ func (mr *MockStateMockRecorder) RetireRequestSeq(arg0 interface{}) *gomock.Call
 }
 
 // StartPrepareTimer mocks base method
-func (m *MockState) StartPrepareTimer(arg0 func()) {
+func (m *MockState) StartPrepareTimer(arg0 uint64, arg1 func()) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartPrepareTimer", arg0)
+	m.ctrl.Call(m, "StartPrepareTimer", arg0, arg1)
 }
 
 // StartPrepareTimer indicates an expected call of StartPrepareTimer
-func (mr *MockStateMockRecorder) StartPrepareTimer(arg0 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) StartPrepareTimer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartPrepareTimer", reflect.TypeOf((*MockState)(nil).StartPrepareTimer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartPrepareTimer", reflect.TypeOf((*MockState)(nil).StartPrepareTimer), arg0, arg1)
 }
 
 // StartRequestTimer mocks base method
-func (m *MockState) StartRequestTimer(arg0 func()) {
+func (m *MockState) StartRequestTimer(arg0 uint64, arg1 func()) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartRequestTimer", arg0)
+	m.ctrl.Call(m, "StartRequestTimer", arg0, arg1)
 }
 
 // StartRequestTimer indicates an expected call of StartRequestTimer
-func (mr *MockStateMockRecorder) StartRequestTimer(arg0 interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) StartRequestTimer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRequestTimer", reflect.TypeOf((*MockState)(nil).StartRequestTimer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartRequestTimer", reflect.TypeOf((*MockState)(nil).StartRequestTimer), arg0, arg1)
 }
 
 // StopPrepareTimer mocks base method
-func (m *MockState) StopPrepareTimer() {
+func (m *MockState) StopPrepareTimer(arg0 uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StopPrepareTimer")
+	m.ctrl.Call(m, "StopPrepareTimer", arg0)
 }
 
 // StopPrepareTimer indicates an expected call of StopPrepareTimer
-func (mr *MockStateMockRecorder) StopPrepareTimer() *gomock.Call {
+func (mr *MockStateMockRecorder) StopPrepareTimer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopPrepareTimer", reflect.TypeOf((*MockState)(nil).StopPrepareTimer))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopPrepareTimer", reflect.TypeOf((*MockState)(nil).StopPrepareTimer), arg0)
 }
 
 // StopRequestTimer mocks base method
-func (m *MockState) StopRequestTimer() {
+func (m *MockState) StopRequestTimer(arg0 uint64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StopRequestTimer")
+	m.ctrl.Call(m, "StopRequestTimer", arg0)
 }
 
 // StopRequestTimer indicates an expected call of StopRequestTimer
-func (mr *MockStateMockRecorder) StopRequestTimer() *gomock.Call {
+func (mr *MockStateMockRecorder) StopRequestTimer(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopRequestTimer", reflect.TypeOf((*MockState)(nil).StopRequestTimer))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopRequestTimer", reflect.TypeOf((*MockState)(nil).StopRequestTimer), arg0)
 }

--- a/core/prepare.go
+++ b/core/prepare.go
@@ -71,7 +71,7 @@ func makePrepareApplier(id uint32, prepareSeq requestSeqPreparer, collectCommitm
 			return fmt.Errorf("Request already prepared")
 		}
 
-		stopPrepTimer(prepare.Msg.ReplicaId)
+		stopPrepTimer(request)
 
 		primaryID := prepare.ReplicaID()
 

--- a/core/prepare.go
+++ b/core/prepare.go
@@ -71,8 +71,6 @@ func makePrepareApplier(id uint32, prepareSeq requestSeqPreparer, collectCommitm
 			return fmt.Errorf("Request already prepared")
 		}
 
-		stopPrepTimer(request)
-
 		primaryID := prepare.ReplicaID()
 
 		if err := collectCommitment(primaryID, prepare); err != nil {
@@ -82,6 +80,8 @@ func makePrepareApplier(id uint32, prepareSeq requestSeqPreparer, collectCommitm
 		if id == primaryID {
 			return nil // primary does not generate Commit
 		}
+
+		stopPrepTimer(request)
 
 		commit := &messages.Commit{
 			Msg: &messages.Commit_M{

--- a/core/prepare_test.go
+++ b/core/prepare_test.go
@@ -148,26 +148,23 @@ func TestMakePrepareApplier(t *testing.T) {
 	assert.Error(t, err, "Request ID already prepared")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", id, ownPrepare).Return(fmt.Errorf("Error")).Once()
 	err = apply(ownPrepare)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", id, ownPrepare).Return(nil).Once()
 	err = apply(ownPrepare)
 	assert.NoError(t, err)
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", primary, prepare).Return(fmt.Errorf("Error")).Once()
 	err = apply(prepare)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", primary, prepare).Return(nil).Once()
+	mock.On("prepareTimerStopper", request).Once()
 	mock.On("generatedUIMessageHandler", commit).Once()
 	err = apply(prepare)
 	assert.NoError(t, err)

--- a/core/prepare_test.go
+++ b/core/prepare_test.go
@@ -103,8 +103,8 @@ func TestMakePrepareApplier(t *testing.T) {
 	handleGeneratedUIMessage := func(msg messages.MessageWithUI) {
 		mock.MethodCalled("generatedUIMessageHandler", msg)
 	}
-	stopPrepTimer := func(id uint32) {
-		mock.MethodCalled("prepareTimerStopper", id)
+	stopPrepTimer := func(request *messages.Request) {
+		mock.MethodCalled("prepareTimerStopper", request)
 	}
 	apply := makePrepareApplier(id, prepareRequestSeq, collectCommitment, handleGeneratedUIMessage, stopPrepTimer)
 
@@ -148,25 +148,25 @@ func TestMakePrepareApplier(t *testing.T) {
 	assert.Error(t, err, "Request ID already prepared")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", id).Once()
+	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", id, ownPrepare).Return(fmt.Errorf("Error")).Once()
 	err = apply(ownPrepare)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", id).Once()
+	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", id, ownPrepare).Return(nil).Once()
 	err = apply(ownPrepare)
 	assert.NoError(t, err)
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", primary).Once()
+	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", primary, prepare).Return(fmt.Errorf("Error")).Once()
 	err = apply(prepare)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("prepareTimerStopper", primary).Once()
+	mock.On("prepareTimerStopper", request).Once()
 	mock.On("commitmentCollector", primary, prepare).Return(nil).Once()
 	mock.On("generatedUIMessageHandler", commit).Once()
 	err = apply(prepare)

--- a/core/request.go
+++ b/core/request.go
@@ -179,16 +179,17 @@ func makeRequestApplier(id, n uint32, provideView viewProvider, handleGeneratedU
 		view, releaseView := provideView()
 		defer releaseView()
 
-		// The primary has to start request/prepare timer, as well.
+		// The primary has to start request timer, as well.
 		// Suppose, the primary is correct, but its messages
 		// are delayed, and other replicas switch to a new
 		// view. In that case, other replicas might rely on
 		// this correct replica to trigger another view
 		// change, should the new primary be faulty.
 		startReqTimer(request.Msg.ClientId, view)
-		startPrepTimer(request, view)
 
 		if isPrimary(view, id, n) {
+			startPrepTimer(request, view)
+
 			prepare := &messages.Prepare{
 				Msg: &messages.Prepare_M{
 					View:      view,

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -409,6 +409,7 @@ func TestMakeRequestTimerStarter(t *testing.T) {
 	defer mock.AssertExpectations(t)
 
 	clientID := rand.Uint32()
+	seq := rand.Uint64()
 	view := rand.Uint64()
 
 	provider, state := setupClientStateProviderMock(t, ctrl, clientID)
@@ -422,11 +423,11 @@ func TestMakeRequestTimerStarter(t *testing.T) {
 	request := &messages.Request{
 		Msg: &messages.Request_M{
 			ClientId: clientID,
-			Seq:      rand.Uint64(),
+			Seq:      seq,
 		},
 	}
 
-	state.EXPECT().StartRequestTimer(gomock.Any()).Do(func(f func()) { f() })
+	state.EXPECT().StartRequestTimer(seq, gomock.Any()).Do(func(_ uint64, f func()) { f() })
 	mock.On("requestTimeoutHandler", view).Once()
 	startTimer(request, view)
 }
@@ -436,6 +437,7 @@ func TestMakeRequestTimerStopper(t *testing.T) {
 	defer ctrl.Finish()
 
 	clientID := rand.Uint32()
+	seq := rand.Uint64()
 	provider, state := setupClientStateProviderMock(t, ctrl, clientID)
 
 	stopTimer := makeRequestTimerStopper(provider)
@@ -443,11 +445,11 @@ func TestMakeRequestTimerStopper(t *testing.T) {
 	request := &messages.Request{
 		Msg: &messages.Request_M{
 			ClientId: clientID,
-			Seq:      rand.Uint64(),
+			Seq:      seq,
 		},
 	}
 
-	state.EXPECT().StopRequestTimer()
+	state.EXPECT().StopRequestTimer(seq)
 	stopTimer(request)
 }
 
@@ -473,6 +475,7 @@ func TestMakePrepareTimerStarter(t *testing.T) {
 	defer mock.AssertExpectations(t)
 
 	clientID := rand.Uint32()
+	seq := rand.Uint64()
 	view := rand.Uint64()
 
 	provider, state := setupClientStateProviderMock(t, ctrl, clientID)
@@ -482,11 +485,11 @@ func TestMakePrepareTimerStarter(t *testing.T) {
 	request := &messages.Request{
 		Msg: &messages.Request_M{
 			ClientId: clientID,
-			Seq:      rand.Uint64(),
+			Seq:      seq,
 		},
 	}
 
-	state.EXPECT().StartPrepareTimer(gomock.Any())
+	state.EXPECT().StartPrepareTimer(seq, gomock.Any())
 	startTimer(request, view)
 }
 
@@ -495,6 +498,7 @@ func TestMakePrepareTimerStopper(t *testing.T) {
 	defer ctrl.Finish()
 
 	clientID := rand.Uint32()
+	seq := rand.Uint64()
 	provider, state := setupClientStateProviderMock(t, ctrl, clientID)
 
 	stopTimer := makePrepareTimerStopper(provider)
@@ -502,11 +506,11 @@ func TestMakePrepareTimerStopper(t *testing.T) {
 	request := &messages.Request{
 		Msg: &messages.Request_M{
 			ClientId: clientID,
-			Seq:      rand.Uint64(),
+			Seq:      seq,
 		},
 	}
 
-	state.EXPECT().StopPrepareTimer()
+	state.EXPECT().StopPrepareTimer(seq)
 	stopTimer(request)
 }
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -127,7 +127,6 @@ func TestMakeRequestApplier(t *testing.T) {
 
 	mock.On("viewProvider").Return(otherView).Once()
 	mock.On("requestTimerStarter", clientID, otherView).Once()
-	mock.On("prepareTimerStarter", request, otherView).Once()
 	mock.On("viewReleaser", otherView).Once()
 	err := apply(request)
 	assert.NoError(t, err)


### PR DESCRIPTION
This pull request fixes some issues with prepare timer that were missed when reviewing #127.

Depending on how we decide to solve the issue noted in "WIP: core: Check request ID before stopping request/prepare timer", we might decide to do the opposite of what "RFC: core: Pass client ID to prepareTimerStarter" suggests.