### PR TITLE
Fix the build status badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GitHub Actions](https://github.com/hyperledger-labs/minbft/workflows/.github/workflows/continuous-integration.yml/badge.svg)](https://github.com/hyperledger-labs/minbft/actions)
+[![GitHub Actions](https://github.com/hyperledger-labs/minbft/workflows/Continuous%20integration/badge.svg)](https://github.com/hyperledger-labs/minbft/actions)
 [![GoDoc](https://godoc.org/github.com/hyperledger-labs/minbft?status.svg)](https://godoc.org/github.com/hyperledger-labs/minbft)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger-labs/minbft)](https://goreportcard.com/report/github.com/hyperledger-labs/minbft)
 


### PR DESCRIPTION
The build status badge in the README is not displayed. This patch fixes the image source to show the badge.

According to the [document](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository), it should be displayed without this patch but I cannot identify a cause. This patch uses another way (not by a file path but by a name) to specify the URL of the badge.