### PR TITLE
Go module: Clarify language compatibility (Go 1.11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,3 +21,5 @@ require (
 	google.golang.org/grpc v1.18.0
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.11


### PR DESCRIPTION
Update go.mod to clarify language compatibility, saying that this project requires Go 1.11 or later (this has been already written in README). Refer to the [document](https://golang.org/doc/go1.12#modules) for more details of `go` directive.

> The go directive in a go.mod file now indicates the version of the language used by the files within that module.

This resolves #151.