### PR TITLE
Introduce environment checker utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ help:
 	@echo '  usig-*           - Make USIG target, where target is one of:'
 	@echo '                     $(usig-target-list)'
 
-build: usig-build
+build: prerequisite-check usig-build
 	go build -o $(builddir)/keytool ./sample/authentication/keytool
 	go build -o $(builddir)/peer ./sample/peer
 

--- a/Makefile
+++ b/Makefile
@@ -78,5 +78,8 @@ lint:
 generate:
 	go generate ./...
 
+prerequisite-check:
+	@bash tools/prerequisite-check.sh
+
 $(usig-target-list):
 	$(MAKE) -C usig/sgx $(patsubst usig-%,%,$@)

--- a/tools/prerequisite-check.sh
+++ b/tools/prerequisite-check.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+REQUIRED_GO_VERSION=1.11
+REQUIRED_SGXSDK_VERSION=2.3.101
+
+show_os_info() {
+	echo "OS: $(. /etc/os-release ; echo $PRETTY_NAME)"
+}
+
+compare_version() {
+	local ver1=$(echo "$1" | awk -F. '{ printf("%d%03d%03d%05d\n", $1,$2,$3,$4); }';)
+	local ver2=$(echo "$2" | awk -F. '{ printf("%d%03d%03d%05d\n", $1,$2,$3,$4); }';)
+
+	if [ "$ver1" -lt "$ver2" ] ; then
+		return 1
+	else
+		return 0
+	fi
+}
+
+check_go_version() {
+	if [[ "$(go version)" =~ go([0-9]+\.[0-9]+\.?[0-9]*) ]] ; then
+		local goversion=${BASH_REMATCH[1]}
+	else
+		echo "Failed to parse go version. Please install it."
+		return 1
+	fi
+
+	if ! compare_version "$goversion" "$REQUIRED_GO_VERSION" ; then
+		echo "Your Go (version $goversion) is older than required version ($REQUIRED_GO_VERSION), so please update it."
+		return 1
+	fi
+
+	echo "Go version: $goversion"
+}
+
+check_sgxsdk_version() {
+	local sgxsdk_version=$(grep ^Version: $SGX_SDK/pkgconfig/libsgx_urts.pc | awk '{print $2}')
+	if [ ! "$sgxsdk_version" ] ; then
+		echo "Failed to parse SGX SDK version from $SGX_SDK/pkgconfig/libsgx_urts.pc. Please make sure that SGX SDK is properly installed."
+		return 1
+	fi
+
+	if ! compare_version $sgxsdk_version $REQUIRED_SGXSDK_VERSION ; then
+		echo "Your SGX SDK (version $sgxsdk_version) is older than required version ($REQUIRED_SGXSDK_VERSION), so please update it."
+		return 1
+	fi
+
+	echo "Intel SGX SDK version: $sgxsdk_version"
+}
+
+check_sgx_support() {
+	if [ "$SGX_MODE" == SIM ] ; then
+		return 0
+	fi
+
+	if make -s --no-print-directory -C tools/sgx-capability check ; then
+		return 0
+	else
+		echo "Intel SGX is not available. Please set environment variable SGX_MODE=SIM."
+		return 1
+	fi
+}
+
+get_sgx_psw_version() {
+	local distro="$(. /etc/os-release ; echo $PRETTY_NAME)"
+	local version=
+
+	if [[ "$distro" =~ "Ubuntu" ]] ; then
+		version=$(dpkg -s libsgx-enclave-common 2> /dev/null | grep '^Version:' | awk '{print $2}')
+	elif [[ "$distro" =~ "Red Hat Enterprise Linux" ]] ; then
+		version=$(rpm -qi libsgx-enclave-common 2> /dev/null | grep '^Version' | awk '{print $3}')
+	elif [[ "$distro" =~ "CentOS" ]] ; then
+		version=$(rpm -qi libsgx-enclave-common 2> /dev/null | grep '^Version' | awk '{print $3}')
+	else
+		echo "Your Linux distribution '$os' is not supported now." >&2
+		return 1
+	fi
+
+	if [ "$version" ] ; then
+		echo "$version"
+		return 0
+	else
+		echo "Failed to get SGX PSW version." >&2
+		return 1
+	fi
+}
+
+check_sgxpsw_version() {
+	if [ "$SGX_MODE" == SIM ] ; then
+		return 0
+	fi
+
+	local version="$(get_sgx_psw_version)"
+	if [ "$version" ] ; then
+		echo "Intel SGX PSW version: $version"
+		return 0
+	else
+		echo "Intel SGX PSW is not installed in your system. Please install it or set environment variable SGX_MODE=SIM."
+		return 1
+	fi
+}
+
+show_os_info
+
+if ! check_go_version ; then
+	exit 1
+fi
+
+if [ ! "$SGX_SDK" ] ; then
+	echo "Environment variable SGX_SDK not set, please make sure to source the environment file given by SGX SDK."
+	exit 1
+fi
+
+if [ "$SGX_MODE" == SIM ] ; then
+	echo "SGX is running in simulation mode."
+fi
+
+if ! check_sgxsdk_version ; then
+	exit 1
+fi
+
+if ! check_sgx_support ; then
+	exit 1
+fi
+
+if ! check_sgxpsw_version ; then
+	exit 1
+fi
+
+echo "Enviroment check passed."

--- a/tools/prerequisite-check.sh
+++ b/tools/prerequisite-check.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "$SKIP_PREREQUISITE_CHECK" ] ; then
+	echo "Skip prerequisite_check."
+	exit 0
+fi
+
 REQUIRED_GO_VERSION=1.11
 REQUIRED_SGXSDK_VERSION=2.3.101
 

--- a/tools/prerequisite-check.sh
+++ b/tools/prerequisite-check.sh
@@ -5,6 +5,10 @@ if [ "$SKIP_PREREQUISITE_CHECK" ] ; then
 	exit 0
 fi
 
+if [ ! "$SGX_MODE" ] ; then
+	SGX_MODE="HW"
+fi
+
 REQUIRED_GO_VERSION=1.11
 REQUIRED_SGXSDK_VERSION=2.3.101
 
@@ -55,7 +59,7 @@ check_sgxsdk_version() {
 }
 
 check_sgx_support() {
-	if [ "$SGX_MODE" == SIM ] ; then
+	if [ "$SGX_MODE" != "HW" ] ; then
 		return 0
 	fi
 
@@ -92,7 +96,7 @@ get_sgx_psw_version() {
 }
 
 check_sgxpsw_version() {
-	if [ "$SGX_MODE" == SIM ] ; then
+	if [ "$SGX_MODE" != "HW" ] ; then
 		return 0
 	fi
 
@@ -117,7 +121,7 @@ if [ ! "$SGX_SDK" ] ; then
 	exit 1
 fi
 
-if [ "$SGX_MODE" == SIM ] ; then
+if [ "$SGX_MODE" != "HW" ] ; then
 	echo "SGX is running in simulation mode."
 fi
 

--- a/tools/sgx-capability/Makefile
+++ b/tools/sgx-capability/Makefile
@@ -1,0 +1,11 @@
+CC = gcc
+SGX_SDK ?= "/opt/intel/sgxsdk"
+
+check-sgx-capability: check-sgx-capability.c
+	$(CC) -I$(SGX_SDK)/include -L$(SGX_SDK)/lib64 -o $@ $? -lsgx_capable
+
+check: check-sgx-capability
+	LD_LIBRARY_PATH=$(SGX_SDK)/lib64:$(LD_LIBRARY_PATH) ./check-sgx-capability
+
+clean:
+	rm -f check-sgx-capability

--- a/tools/sgx-capability/check-sgx-capability.c
+++ b/tools/sgx-capability/check-sgx-capability.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 NEC Solution Innovators, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This program is based on `sgx_enable.c` in the following repository:
+ * https://github.com/intel/sgx-software-enable
+ *
+ * Copyright (C) 2011-2019 Intel Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdio.h>
+#include <sgx_capable.h>
+
+int main (int argc, char *argv[])
+{
+	sgx_status_t status;
+	sgx_device_status_t result;
+
+	status= sgx_cap_get_status(&result);
+	if (status != SGX_SUCCESS) {
+		switch(status) {
+		case SGX_ERROR_NO_PRIVILEGE:
+			fprintf(stderr, "could not examine the EFI filesystem\n");
+			return 1;
+		case SGX_ERROR_INVALID_PARAMETER:
+		case SGX_ERROR_UNEXPECTED:
+			fprintf(stderr, "could not get SGX status: ");
+		default:
+			fprintf(stderr, "sgx_cap_get_status returned 0x%04x\n", status);
+			return 1;
+		}
+	}
+
+	if (result == SGX_ENABLED) {
+		printf("Intel SGX is supported and enabled on this system.\n");
+		return 0;
+	} else if (result == SGX_DISABLED_UNSUPPORTED_CPU) {
+		printf("This CPU does not support Intel SGX.\n");
+		return 1;
+	} else if (result == SGX_DISABLED_LEGACY_OS) {
+		printf("This processor supports Intel SGX but was booted in legacy mode.\n");
+		printf("A UEFI boot is required to determine whether or not your BIOS\n");
+		printf("supports Intel SGX.\n");
+		return 1;
+	} else if (result == SGX_DISABLED) {
+		printf("Intel SGX is explicitly disabled on your system. It may be\n");
+		printf("disabled in the BIOS, or the BIOS may not support Intel SGX.\n");
+		return 1;
+	} else if (result == SGX_DISABLED_MANUAL_ENABLE) {
+		printf("Intel SGX is explicitly disabled, and your BIOS does not\n");
+		printf("support the \"software enable\" option. Check your BIOS for an\n");
+		printf("explicit option to enable Intel SGX.\n");
+		return 1;
+	} else if (result == SGX_DISABLED_REBOOT_REQUIRED) {
+		printf("The software enable has been performed on this system and\n");
+		printf("Intel SGX will be enabled after the system is rebooted.\n");
+		return 1;
+	} else if (result != SGX_DISABLED_SCI_AVAILABLE) {
+		printf("I couldn't make sense of your system.\n");
+		fprintf(stderr, "sgx_cap_get_status returned 0x%04x\n", result);
+		return 1;
+	} else {
+		printf("Unknown result code.\n");
+		fprintf(stderr, "sgx_cap_get_status returned 0x%04x\n", result);
+		return 1;
+	}
+}


### PR DESCRIPTION
This pull request is suggesting to introduce a tool to check whether required libraries and settings are properly added. According to [the document](https://software.intel.com/en-us/articles/properly-detecting-intel-software-guard-extensions-in-your-applications), we can use `sgx_cap_get_status()` to detect SGX availability, so this tool does it. I expect that it would help users find setting issues for their own.

I show below how `make prerequisite-check` works as examples:
- when the system supports and enables SGX:
  ~~~
  ubuntu@sgx:~/minbft$ make prerequisite-check
  OS: Ubuntu 18.04.3 LTS
  Go version: 1.13.6
  Intel SGX SDK version: 2.8.100.3
  Intel SGX is supported and enabled on this system.
  Intel SGX PSW version: 2.8.100.3-bionic1
  Enviroment check passed.
  ~~~
- when SGX is unavailable:
  ~~~
  ubuntu@nosgx:~/minbft$ make prerequisite-check
  OS: Ubuntu 18.04.3 LTS
  Go version: 1.13.6
  Intel SGX SDK version: 2.3.101.46683
  This CPU does not support Intel SGX.
  Makefile:8: recipe for target 'check' failed
  make[1]: *** [check] Error 1
  Intel SGX is not available. Please set environment variable SGX_MODE=SIM.
  Makefile:82: recipe for target 'prerequisite-check' failed
  make: *** [prerequisite-check] Error 1
  ~~~
- when SGX is unavailable and `SGX_MODE=SIM` is set:
  ~~~
  ubuntu@nosgx:~/minbft$ SGX_MODE=SIM make prerequisite-check
  OS: Ubuntu 18.04.3 LTS
  Go version: 1.13.6
  Intel SGX SDK version: 2.3.101.46683
  Enviroment check passed.
  ~~~

Expected to resolve #150.

Some notes which we might want to discuss:
- I mainly borrowed code from [`sgx_enable.c`](https://github.com/intel/sgx-software-enable/blob/master/sgx_enable.c) for `check-sgx-capability.c`, but substantially removed lines because it does "software-enable" part not only detecting SGX support. In this case, how do we handle license matter?
- Currently `prerequisite-check.sh` aborts if version check fails, but that might be too strict. If you think just warning is fine, I'll do it. And the script also has an assumption of using Ubuntu, that might be undesirable limitation in a long run.