### PR TITLE
forward REQUEST messages to primary when prepare timer expires

### DIFF
--- a/core/internal/messagelog/messagelog.go
+++ b/core/internal/messagelog/messagelog.go
@@ -38,15 +38,15 @@ import (
 // indicates the returned channel should be closed. Nil channel may be
 // passed if there's no need to close the returned channel.
 type MessageLog interface {
-	Append(msg messages.ReplicaMessage)
-	Stream(done <-chan struct{}) <-chan messages.ReplicaMessage
+	Append(msg messages.Message)
+	Stream(done <-chan struct{}) <-chan messages.Message
 }
 
 type messageLog struct {
 	lock sync.RWMutex
 
 	// Messages in order added
-	msgs []messages.ReplicaMessage
+	msgs []messages.Message
 
 	// Buffered channels to notify about new messages
 	newAdded []chan<- struct{}
@@ -57,7 +57,7 @@ func New() MessageLog {
 	return &messageLog{}
 }
 
-func (log *messageLog) Append(msg messages.ReplicaMessage) {
+func (log *messageLog) Append(msg messages.Message) {
 	log.lock.Lock()
 	defer log.lock.Unlock()
 
@@ -71,14 +71,13 @@ func (log *messageLog) Append(msg messages.ReplicaMessage) {
 	}
 }
 
-func (log *messageLog) Stream(done <-chan struct{}) <-chan messages.ReplicaMessage {
-	ch := make(chan messages.ReplicaMessage)
+func (log *messageLog) Stream(done <-chan struct{}) <-chan messages.Message {
+	ch := make(chan messages.Message)
 	go log.supplyMessages(ch, done)
-
 	return ch
 }
 
-func (log *messageLog) supplyMessages(ch chan<- messages.ReplicaMessage, done <-chan struct{}) {
+func (log *messageLog) supplyMessages(ch chan<- messages.Message, done <-chan struct{}) {
 	defer close(ch)
 
 	newAdded := make(chan struct{}, 1)

--- a/core/internal/messagelog/messagelog_test.go
+++ b/core/internal/messagelog/messagelog_test.go
@@ -64,7 +64,7 @@ func TestStream(t *testing.T) {
 		log.Append(msg)
 	}
 
-	receiveMessages := func(ch <-chan messages.ReplicaMessage) {
+	receiveMessages := func(ch <-chan messages.Message) {
 		for i, msg := range msgs {
 			assert.Equalf(t, msg, <-ch, "Unexpected message %d", i)
 		}

--- a/core/internal/messagelog/mocks/mock.go
+++ b/core/internal/messagelog/mocks/mock.go
@@ -34,7 +34,7 @@ func (m *MockMessageLog) EXPECT() *MockMessageLogMockRecorder {
 }
 
 // Append mocks base method
-func (m *MockMessageLog) Append(arg0 messages.ReplicaMessage) {
+func (m *MockMessageLog) Append(arg0 messages.Message) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Append", arg0)
 }
@@ -46,10 +46,10 @@ func (mr *MockMessageLogMockRecorder) Append(arg0 interface{}) *gomock.Call {
 }
 
 // Stream mocks base method
-func (m *MockMessageLog) Stream(arg0 <-chan struct{}) <-chan messages.ReplicaMessage {
+func (m *MockMessageLog) Stream(arg0 <-chan struct{}) <-chan messages.Message {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stream", arg0)
-	ret0, _ := ret[0].(<-chan messages.ReplicaMessage)
+	ret0, _ := ret[0].(<-chan messages.Message)
 	return ret0
 }
 

--- a/core/replica.go
+++ b/core/replica.go
@@ -57,13 +57,14 @@ func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (api.Rep
 	logOpts := newOptions(opts...)
 
 	messageLog := messagelog.New()
+	requestForward := make(map[uint32]messagelog.MessageLog)
 	logger := makeLogger(id, logOpts)
 
-	if err := startPeerConnections(id, n, stack, messageLog, logger); err != nil {
+	if err := startPeerConnections(id, n, stack, messageLog, logger, requestForward); err != nil {
 		return nil, fmt.Errorf("Failed to start peer connections: %s", err)
 	}
 
-	handle := defaultIncomingMessageHandler(id, messageLog, configer, stack, logger)
+	handle := defaultIncomingMessageHandler(id, messageLog, configer, stack, logger, requestForward)
 	handleStream := makeMessageStreamHandler(handle, logger)
 
 	go handleGeneratedPeerMessages(messageLog, handle, logger)

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -30,6 +30,7 @@ import (
 	testifymock "github.com/stretchr/testify/mock"
 
 	"github.com/hyperledger-labs/minbft/core/internal/clientstate"
+	"github.com/hyperledger-labs/minbft/core/internal/messagelog"
 	"github.com/hyperledger-labs/minbft/messages"
 
 	mock_api "github.com/hyperledger-labs/minbft/api/mocks"
@@ -415,7 +416,10 @@ func TestMakePrepareTimerStarter(t *testing.T) {
 
 	provider, state := setupClientStateProviderMock(t, ctrl, clientID)
 
-	startTimer := makePrepareTimerStarter(provider, logging.MustGetLogger(module))
+	requestForward := map[uint32]messagelog.MessageLog{
+		uint32(0): messagelog.New(),
+	}
+	startTimer := makePrepareTimerStarter(uint32(0), provider, logging.MustGetLogger(module), requestForward)
 
 	request := messageImpl.NewRequest(clientID, seq, nil)
 


### PR DESCRIPTION
This pull request proposes to introduce request forwarding to handle some faulty case in request submission. This allows the MinBFT cluster to accept a request in some cases when the primary does not receive it from the client. The table below provides brief summary of how the behavior changes:

| case           | origin | patched | 
|----------------|--------|---------| 
| R0R1R2         | pass   | pass    | 
| R0             | fail   | fail    | 
| R0R1           | pass   | pass    | 
| R1             | fail   | fail    | 
| R1R2           | fail   | pass    | 
| R0R1Q2         | pass   | pass    | 
| R0Q1           | pass   | pass    | 
| R1Q2           | fail   | pass    | 

Here we consider a minimum typical cluster (N is 3 and replica 0 is the primary.) Case ID shows which replica(s) a client sends REQUEST to. For example, in case "R0R1" a client sends REQUEST only to replica 0 and 1. In another example "R0R1Q2", a client sends proper REQUEST messages to replica 0 and 1, and a modified REQUEST message (with the same seq) to replica 2. In the result columns, "pass" means that the cluster reaches a consensus.

The most interesting case is "R1R2", where a client sends the proper REQUEST messages to replica 1 and 2. This case becomes "pass" due to request forwarding.

What I noticed while working on this is that case "R1" fails even with this patch. This is because in current implementation the replica could send REPLY to the client only when the replica received the REQUEST directly from the client (i.e. a replica who got a forwarded request can't send REPLY.) Similarly, a backup replica which didn't receive REQUEST from the client and processed REQUEST embedded in the PREPARE message can't send REPLY message to its requester. I guess that these are not due to some specific reason, but it's just implemented now as such. So we can do some to fix them in the future if we think it's worth doing.

Resolves #140
Resolves #5
