### PR TITLE
core: Use longfunc in defaultLogPrefix

### DIFF
--- a/core/replica.go
+++ b/core/replica.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	module           = "minbft"
-	defaultLogPrefix = `%{color}[%{module}] %{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset}`
+	defaultLogPrefix = `%{color}[%{module}] %{time:15:04:05.000} %{longfunc} ▶ %{level:.4s} %{id:03x}%{color:reset}`
 )
 
 var messageImpl = protobufMessages.NewImpl()


### PR DESCRIPTION
This pull request is to improve default log format by showing generator functions of anonymous functions.

Resolves #167
