### PR TITLE
Introduce tests for a few Byzantine faulty cases

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,13 @@ type Configer interface {
 
 	// starts when sends VIEW-CHANGE and stops when receives a valid NEW-VIEW
 	TimeoutViewChange() time.Duration
+
+	// returns true if replica @replicaID is configured to ignore
+	// (i.e. refuse to send any message to) replica @peerID via
+	// replica setting debug.selectiveignorereplica.
+	//
+	// This interface is supposed to used only for debug purpose.
+	SelectiveIgnorantReplicas(replicaID, peerID uint32) bool
 }
 
 //======= Interface for module 'network' =======

--- a/api/mocks/mock.go
+++ b/api/mocks/mock.go
@@ -90,6 +90,20 @@ func (mr *MockConfigerMockRecorder) N() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "N", reflect.TypeOf((*MockConfiger)(nil).N))
 }
 
+// SelectiveIgnorantReplicas mocks base method
+func (m *MockConfiger) SelectiveIgnorantReplicas(arg0, arg1 uint32) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SelectiveIgnorantReplicas", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SelectiveIgnorantReplicas indicates an expected call of SelectiveIgnorantReplicas
+func (mr *MockConfigerMockRecorder) SelectiveIgnorantReplicas(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectiveIgnorantReplicas", reflect.TypeOf((*MockConfiger)(nil).SelectiveIgnorantReplicas), arg0, arg1)
+}
+
 // TimeoutPrepare mocks base method
 func (m *MockConfiger) TimeoutPrepare() time.Duration {
 	m.ctrl.T.Helper()

--- a/core/bft_test.go
+++ b/core/bft_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 NEC Solution Innovators, Ltd.
+//
+// Authors: Naoya Horiguchi <naoya.horiguchi@nec.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package minbft_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"text/template"
+
+	"github.com/hyperledger-labs/minbft/sample/config"
+)
+
+const cfgBftTemplate = `
+protocol:
+  "n": {{.N}}
+  f: {{getF .N}}
+  checkpointPeriod: 10
+  logsize: 20
+  timeout:
+    request: 2s
+    viewchange: 3s
+debug:
+  selectiveignorantreplicas:
+    {{range $k, $v := .Ignore}}{{$k}}:{{range $s := $v}} {{$s}}{{end}}
+    {{end}}
+`
+
+// createTestCfgBft creates config file for Byzantine faulty cases.
+func createTestCfgBft(numReplica int, ignore map[string][]int) []byte {
+	var err error
+	var testCfgBft bytes.Buffer
+
+	t := template.New("cfgBftTemplate")
+	t = t.Funcs(template.FuncMap{
+		"getF": func(n int) int { return (n - 1) / 2 },
+	})
+	t = template.Must(t.Parse(cfgBftTemplate))
+	if err = t.Execute(&testCfgBft, struct {
+		N      int
+		Ignore map[string][]int
+	}{
+		N:      numReplica,
+		Ignore: ignore,
+	}); err != nil {
+		panic(err)
+	}
+	return testCfgBft.Bytes()
+}
+
+func initTestnetPeersBFT(numReplica, numClient int, ignore map[string][]int) {
+	resetFixture()
+
+	// generate config, keys
+	testCfgBft := createTestCfgBft(numReplica, ignore)
+	testKeys := createTestKeys(numReplica, numClient)
+
+	cfg := config.New() // configer shared by all replicas
+	err := cfg.ReadConfig(bytes.NewBuffer(testCfgBft), "yaml")
+	if err != nil {
+		panic(err)
+	}
+
+	makeReplicas(numReplica, testKeys, cfg)
+	makeClients(numClient, testKeys, cfg)
+}
+
+func TestByzantineFault(t *testing.T) {
+	testCases := []struct {
+		numReplica int
+		numClient  int
+		ignore     map[string][]int
+	}{
+		{numReplica: 3, numClient: 1, ignore: map[string][]int{"2": {1}}},
+		{numReplica: 3, numClient: 1, ignore: map[string][]int{"2": {0}}},
+		{numReplica: 3, numClient: 1, ignore: map[string][]int{"0": {1}}},
+	}
+	for _, tc := range testCases {
+		// setup
+		initTestnetPeersBFT(tc.numReplica, tc.numClient, tc.ignore)
+
+		t.Run(fmt.Sprintf("TestnetAcceptOneRequest/r=%d/c=%d/ignore=%v", tc.numReplica, tc.numClient, tc.ignore), testAcceptOneRequest)
+	}
+}

--- a/core/replica.go
+++ b/core/replica.go
@@ -59,7 +59,7 @@ func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (api.Rep
 	messageLog := messagelog.New()
 	logger := makeLogger(id, logOpts)
 
-	if err := startPeerConnections(id, n, stack, messageLog, logger); err != nil {
+	if err := startPeerConnections(id, configer, stack, messageLog, logger); err != nil {
 		return nil, fmt.Errorf("Failed to start peer connections: %s", err)
 	}
 

--- a/sample/config/viperconfiger.go
+++ b/sample/config/viperconfiger.go
@@ -22,6 +22,8 @@ import (
 	"log"
 	"math"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -157,6 +159,25 @@ func (c *ViperConfiger) TimeoutPrepare() time.Duration {
 // TimeoutViewChange returns the timeout to receive NEW-VIEW message
 func (c *ViperConfiger) TimeoutViewChange() time.Duration {
 	return c.getTimeDuration("protocol.timeout.viewchange")
+}
+
+// SelectiveIgnorantReplicas returns true if replica @replicaID
+// is configured to ignore (i.e. refuse to send any message to)
+// replica @peerID via replica setting debug.selectiveignorereplica.
+func (c *ViperConfiger) SelectiveIgnorantReplicas(replicaID, peerID uint32) bool {
+	tmp := c.config.GetStringMapString("debug.selectiveignorantreplicas")
+	val, ok := tmp[strconv.Itoa(int(replicaID))]
+	if !ok {
+		return false
+	}
+	j := strings.Split(val, " ")
+	for _, v := range j {
+		k, _ := strconv.Atoi(v)
+		if uint32(k) == peerID {
+			return true
+		}
+	}
+	return false
 }
 
 // Peers returns a list peers


### PR DESCRIPTION
This pull request is trying to add test code for a few simple Byzantine faulty cases. As discussed in #127, we could have a hybrid approach of the complementary two approaches:

- (1) tests whole network's behavior by mimicking all replicas individually, and
- (2) tests one tested replica by mimicking surrounding network including the all other replicas.

This PR make a step on approach (1), and some of the simplest cases will be covered. Please see individual patches for more details.

One thing I'd like to discuss is that I don't think that inserting some hook into main logic like below is clean and optimal.

https://github.com/Naoya-Horiguchi/minbft/blob/94dfc5059779f71c2df58efaa411d597139beb94/core/message-handling.go#L256-L268

One possible better way to me is to convert package method `startPeerConnections` into instance method  of `replica struct`, then it's overwritable by introducing another variant struct like `replicaBftTest struct` which embeds the original `replica struct`. This approach seems better in the way that we can clearly separate the test logic from the main logic, and in another way that we could generalize the approach to other functions components in minbft package. One downside is that the code need to be changed in design level and the cost of the change might not be small.

I'm glad if I can hear about any ideas.
