### PR TITLE
Update the CI environment

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,9 @@
 name: Continuous integration
 on: [push, pull_request]
 env:
-  SGX_SDK_URL: https://download.01.org/intel-sgx/linux-2.3.1/ubuntu18.04/sgx_linux_x64_sdk_2.3.101.46683.bin
+  SGX_SDK_URL: https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.101.2.bin
   GOLANGCI_LINT_URL: https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-  GOLANGCI_LINT_VERSION: v1.21.0
+  GOLANGCI_LINT_VERSION: v1.27.0
   SGX_MODE: SIM
 
 jobs:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        go: [1.11, 1.13]
+        go: [1.11, 1.14]
     steps:
       - name: Install Intel SGX SDK
         run: |
@@ -20,7 +20,7 @@ jobs:
           chmod +x sgx_linux_x64_sdk.bin
           echo -e "no\n/opt/intel" | sudo ./sgx_linux_x64_sdk.bin
           rm sgx_linux_x64_sdk.bin
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
       - name: Print Go version
@@ -29,7 +29,7 @@ jobs:
       - name: Install GolangCI-Lint
         run: |
           curl -sfL $GOLANGCI_LINT_URL | sudo sh -s -- -b /usr/local/bin $GOLANGCI_LINT_VERSION
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Test
         run: |
           source /opt/intel/sgxsdk/environment

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ sudo apt-get install build-essential pkg-config
 ### Golang ###
 
 Go 1.11 or later is required to build this project (tested with Go 1.11
-and 1.13). For installation instructions please visit [this page]
-(https://golang.org/doc/install).
+and 1.14). For installation instructions please visit
+[this page](https://golang.org/doc/install).
 
 ### Intel® SGX SDK ###
 
 The Intel® SGX enclave implementation has been tested with Intel® SGX
-SDK for Linux version 2.3.1. For installation instuctions please visit
+SDK for Linux version 2.9.1. For installation instuctions please visit
 [download page][sgx-downloads].
 Please note that Intel SGX has two operation modes and required software
 components depend on operation mode.
@@ -162,8 +162,9 @@ export SGX_MODE=SIM
 ## Getting Started ##
 
 This is a Go module and can be placed anywhere; no need to be in
-GOPATH. If this is placed in GOPATH, please make sure that the
-environment variable `GO111MODULE=on` has set to activate module mode.
+GOPATH. If this is placed in GOPATH and you are using Go 1.11 or 1.12,
+please make sure that the environment variable `GO111MODULE=on` has
+set to activate module mode.
 
 All following commands are supposed to be run in the root of the
 module's source tree.


### PR DESCRIPTION
This patch update our CI environment to use the latest versions of:
- Intel SGX SDK (2.9.1)
- GolangCI-Lint (1.27.0)
- Go (1.11 and 1.14)

Note that since Go 1.13, [module-mode is enabled](https://github.com/golang/go/wiki/Modules#go-113) even the project is located inside GOPATH with default `GO111MODULE` setting. So we don't need to set `GO111MODULE=on` explicitly.

This PR is a part of #182.