### PR TITLE
Remove duplicate UI parsing

### DIFF
--- a/core/commit.go
+++ b/core/commit.go
@@ -74,7 +74,7 @@ func makeCommitValidator(verifyUI uiVerifier, validatePrepare prepareValidator) 
 			return fmt.Errorf("Invalid Prepare: %s", err)
 		}
 
-		if _, err := verifyUI(commit); err != nil {
+		if err := verifyUI(commit); err != nil {
 			return fmt.Errorf("UI is not valid: %s", err)
 		}
 

--- a/core/commit.go
+++ b/core/commit.go
@@ -149,11 +149,7 @@ func makeCommitmentCounter(f uint32) commitmentCounter {
 	return func(replicaID uint32, prepare messages.Prepare) (done bool, err error) {
 		primaryID := prepare.ReplicaID()
 		prepareView := prepare.View()
-		prepareUI, err := parseMessageUI(prepare)
-		if err != nil {
-			panic(err)
-		}
-		prepareCV := prepareUI.Counter
+		prepareCV := prepare.UI().Counter
 
 		if prepareView < view {
 			return false, nil

--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -205,13 +205,8 @@ func TestMakeCommitmentCollectorConcurrent(t *testing.T) {
 					releaseSeq()
 				}
 
-				prepareUI := &usig.UI{
-					Counter: cv,
-				}
-				prepareUIBytes, _ := prepareUI.MarshalBinary()
-
 				prepare := messageImpl.NewPrepare(0, 0, request)
-				prepare.SetUIBytes(prepareUIBytes)
+				prepare.SetUI(&usig.UI{Counter: cv})
 				_ = prepareSeq(request)
 
 				err := collect(uint32(id), prepare)
@@ -379,13 +374,8 @@ func TestMakeCommitmentCounter(t *testing.T) {
 }
 
 func makePrepare(p, v, cv int) messages.Prepare {
-	prepareUI := &usig.UI{
-		Counter: uint64(cv),
-	}
-	prepareUIBytes, _ := prepareUI.MarshalBinary()
 	request := messageImpl.NewRequest(0, rand.Uint64(), nil)
 	prepare := messageImpl.NewPrepare(uint32(p), uint64(v), request)
-	prepare.SetUIBytes(prepareUIBytes)
-
+	prepare.SetUI(&usig.UI{Counter: uint64(cv)})
 	return prepare
 }

--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -46,9 +46,9 @@ func TestMakeCommitValidator(t *testing.T) {
 	primary := primaryID(n, view)
 	backup := randOtherReplicaID(primary, n)
 
-	verifyUI := func(msg messages.CertifiedMessage) (*usig.UI, error) {
+	verifyUI := func(msg messages.CertifiedMessage) error {
 		args := mock.MethodCalled("uiVerifier", msg)
-		return args.Get(0).(*usig.UI), args.Error(1)
+		return args.Error(0)
 	}
 	validatePrepare := func(prepare messages.Prepare) error {
 		args := mock.MethodCalled("prepareValidator", prepare)
@@ -59,28 +59,23 @@ func TestMakeCommitValidator(t *testing.T) {
 	request := messageImpl.NewRequest(0, rand.Uint64(), nil)
 	prepare := messageImpl.NewPrepare(primary, view, request)
 
-	ui := &usig.UI{Counter: rand.Uint64()}
-	makeCommitMsg := func(id uint32) messages.Commit {
-		return messageImpl.NewCommit(id, prepare)
-	}
-
-	commit := makeCommitMsg(primary)
+	commit := messageImpl.NewCommit(primary, prepare)
 	err := validate(commit)
 	assert.Error(t, err, "Commit from primary")
 
-	commit = makeCommitMsg(backup)
+	commit = messageImpl.NewCommit(backup, prepare)
 
 	mock.On("prepareValidator", prepare).Return(fmt.Errorf("UI not valid")).Once()
 	err = validate(commit)
 	assert.Error(t, err, "Invalid Prepare")
 
 	mock.On("prepareValidator", prepare).Return(nil).Once()
-	mock.On("uiVerifier", commit).Return((*usig.UI)(nil), fmt.Errorf("UI not valid")).Once()
+	mock.On("uiVerifier", commit).Return(fmt.Errorf("UI not valid")).Once()
 	err = validate(commit)
 	assert.Error(t, err, "Invalid UI")
 
 	mock.On("prepareValidator", prepare).Return(nil).Once()
-	mock.On("uiVerifier", commit).Return(ui, nil).Once()
+	mock.On("uiVerifier", commit).Return(nil).Once()
 	err = validate(commit)
 	assert.NoError(t, err)
 }

--- a/core/prepare.go
+++ b/core/prepare.go
@@ -56,7 +56,7 @@ func makePrepareValidator(n uint32, verifyUI uiVerifier, validateRequest request
 			return fmt.Errorf("Request invalid: %s", err)
 		}
 
-		if _, err := verifyUI(prepare); err != nil {
+		if err := verifyUI(prepare); err != nil {
 			return fmt.Errorf("UI not valid: %s", err)
 		}
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -168,10 +168,8 @@ func TestMakeRequestExecutor(t *testing.T) {
 	clientID := rand.Uint32()
 	replicaID := rand.Uint32()
 
-	expectedOperation := make([]byte, 1)
-	expectedResult := make([]byte, 1)
-	rand.Read(expectedOperation)
-	rand.Read(expectedResult)
+	expectedOperation := randBytes()
+	expectedResult := randBytes()
 
 	request := messageImpl.NewRequest(clientID, seq, expectedOperation)
 	expectedReply := messageImpl.NewReply(replicaID, clientID, seq, expectedResult)
@@ -203,10 +201,8 @@ func TestMakeOperationExecutor(t *testing.T) {
 	consumer := mock_api.NewMockRequestConsumer(ctrl)
 	executor := makeOperationExecutor(consumer)
 
-	op := make([]byte, 1)
-	expectedRes := make([]byte, 1)
-	rand.Read(op)
-	rand.Read(expectedRes)
+	op := randBytes()
+	expectedRes := randBytes()
 	resChan := make(chan []byte, 1)
 
 	// Normal execution

--- a/core/testutils_test.go
+++ b/core/testutils_test.go
@@ -63,3 +63,8 @@ func randOtherReplicaID(id, n uint32) uint32 {
 	offset := rand.Intn(int(n)-1) + 1
 	return (id + uint32(offset)) % n
 }
+
+// randBytes returns a slice of random bytes
+func randBytes() []byte {
+	return []byte{byte(rand.Int())} // nolint:gosec
+}

--- a/core/usig-ui.go
+++ b/core/usig-ui.go
@@ -38,9 +38,10 @@ type uiCapturer func(msg messages.CertifiedMessage) (new bool, release func())
 
 // uiVerifier verifies USIG certificate attached to a message.
 //
-// USIG certificate is verified and the UI is returned if it is valid
-// for the message. A UI with zero counter value is never valid.
-type uiVerifier func(msg messages.CertifiedMessage) (ui *usig.UI, err error)
+// It verifies if the UI assigned to the message is correct and its
+// USIG certificate is valid for the message. A UI with zero counter
+// value is never valid.
+type uiVerifier func(msg messages.CertifiedMessage) error
 
 // uiAssigner assigns a unique identifier to a message.
 //
@@ -65,22 +66,22 @@ func makeUICapturer(providePeerState peerstate.Provider) uiCapturer {
 // makeUIVerifier constructs uiVerifier using the supplied external
 // authenticator to verify USIG certificates.
 func makeUIVerifier(authen api.Authenticator, extractAuthenBytes authenBytesExtractor) uiVerifier {
-	return func(msg messages.CertifiedMessage) (*usig.UI, error) {
+	return func(msg messages.CertifiedMessage) error {
 		ui, err := parseMessageUI(msg)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		if ui.Counter == uint64(0) {
-			return nil, fmt.Errorf("Invalid (zero) counter value")
+			return fmt.Errorf("Invalid (zero) counter value")
 		}
 
 		authenBytes := extractAuthenBytes(msg)
 		if err := authen.VerifyMessageAuthenTag(api.USIGAuthen, msg.ReplicaID(), authenBytes, msg.UIBytes()); err != nil {
-			return nil, fmt.Errorf("Failed verifying USIG certificate: %s", err)
+			return fmt.Errorf("Failed verifying USIG certificate: %s", err)
 		}
 
-		return ui, nil
+		return nil
 	}
 }
 

--- a/core/usig-ui_test.go
+++ b/core/usig-ui_test.go
@@ -52,8 +52,7 @@ func TestMakeUIVerifier(t *testing.T) {
 
 	id := rand.Uint32()
 	cv := rand.Uint64()
-	authenBytes := make([]byte, 1)
-	rand.Read(authenBytes)
+	authenBytes := randBytes()
 
 	// Correct UI
 	msg, _ := makeMockUIMsg(ctrl, id, cv)
@@ -123,9 +122,7 @@ func makeMockUIMsg(ctrl *gomock.Controller, replicaID uint32, cv uint64) (messag
 	msg := mock_messages.NewMockCertifiedMessage(ctrl)
 	msg.EXPECT().ReplicaID().Return(replicaID).AnyTimes()
 
-	cert := make([]byte, 1)
-	rand.Read(cert)
-	ui := &usig.UI{Counter: cv, Cert: cert}
+	ui := &usig.UI{Counter: cv, Cert: randBytes()}
 	uiBytes, _ := ui.MarshalBinary()
 	msg.EXPECT().UIBytes().Return(uiBytes).AnyTimes()
 

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -46,10 +46,8 @@ func TestMakeMessageSigner(t *testing.T) {
 	authen := mock_api.NewMockAuthenticator(ctrl)
 	signer := makeMessageSigner(authen, extractAuthenBytes)
 
-	authenBytes := make([]byte, 1)
-	signature := make([]byte, 1)
-	rand.Read(authenBytes)
-	rand.Read(signature)
+	authenBytes := randBytes()
+	signature := randBytes()
 
 	msg := struct {
 		*mock_messages.MockMessage
@@ -87,10 +85,8 @@ func TestMakeMessageSignatureVerifier(t *testing.T) {
 	clientID := rand.Uint32()
 	replicaID := rand.Uint32()
 
-	authenBytes := make([]byte, 1)
-	signature := make([]byte, 1)
-	rand.Read(authenBytes)
-	rand.Read(signature)
+	authenBytes := randBytes()
+	signature := randBytes()
 
 	signedMsg := mock_messages.NewMockSignedMessage(ctrl)
 	signedMsg.EXPECT().Signature().Return(signature).AnyTimes()

--- a/messages/api.go
+++ b/messages/api.go
@@ -17,6 +17,8 @@ package messages
 
 import (
 	"encoding"
+
+	"github.com/hyperledger-labs/minbft/usig"
 )
 
 // MessageImpl provides an implementation of the message representation.
@@ -60,8 +62,8 @@ type PeerMessage interface {
 // CertifiedMessage represents a message certified with a UI.
 type CertifiedMessage interface {
 	ReplicaMessage
-	UIBytes() []byte
-	SetUIBytes(ui []byte)
+	UI() *usig.UI
+	SetUI(ui *usig.UI)
 }
 
 // SignedMessage represents a message signed with a normal signature.

--- a/messages/authen.go
+++ b/messages/authen.go
@@ -67,7 +67,7 @@ func writeAuthenBytes(buf io.Writer, m Message) {
 		prep := m.Prepare()
 		_ = binary.Write(buf, binary.BigEndian, prep.ReplicaID())
 		writeAuthenBytes(buf, prep)
-		_, _ = buf.Write(prep.UIBytes())
+		_ = binary.Write(buf, binary.BigEndian, prep.UI().Counter)
 	case ReqViewChange:
 		_ = binary.Write(buf, binary.BigEndian, m.NewView())
 	default:

--- a/messages/mocks/mock.go
+++ b/messages/mocks/mock.go
@@ -6,6 +6,7 @@ package mock_messages
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	usig "github.com/hyperledger-labs/minbft/usig"
 	reflect "reflect"
 )
 
@@ -315,30 +316,30 @@ func (mr *MockCertifiedMessageMockRecorder) ReplicaID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicaID", reflect.TypeOf((*MockCertifiedMessage)(nil).ReplicaID))
 }
 
-// SetUIBytes mocks base method
-func (m *MockCertifiedMessage) SetUIBytes(arg0 []byte) {
+// SetUI mocks base method
+func (m *MockCertifiedMessage) SetUI(arg0 *usig.UI) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetUIBytes", arg0)
+	m.ctrl.Call(m, "SetUI", arg0)
 }
 
-// SetUIBytes indicates an expected call of SetUIBytes
-func (mr *MockCertifiedMessageMockRecorder) SetUIBytes(arg0 interface{}) *gomock.Call {
+// SetUI indicates an expected call of SetUI
+func (mr *MockCertifiedMessageMockRecorder) SetUI(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUIBytes", reflect.TypeOf((*MockCertifiedMessage)(nil).SetUIBytes), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUI", reflect.TypeOf((*MockCertifiedMessage)(nil).SetUI), arg0)
 }
 
-// UIBytes mocks base method
-func (m *MockCertifiedMessage) UIBytes() []byte {
+// UI mocks base method
+func (m *MockCertifiedMessage) UI() *usig.UI {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UIBytes")
-	ret0, _ := ret[0].([]byte)
+	ret := m.ctrl.Call(m, "UI")
+	ret0, _ := ret[0].(*usig.UI)
 	return ret0
 }
 
-// UIBytes indicates an expected call of UIBytes
-func (mr *MockCertifiedMessageMockRecorder) UIBytes() *gomock.Call {
+// UI indicates an expected call of UI
+func (mr *MockCertifiedMessageMockRecorder) UI() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UIBytes", reflect.TypeOf((*MockCertifiedMessage)(nil).UIBytes))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UI", reflect.TypeOf((*MockCertifiedMessage)(nil).UI))
 }
 
 // MockSignedMessage is a mock of SignedMessage interface

--- a/messages/protobuf/commit.go
+++ b/messages/protobuf/commit.go
@@ -21,17 +21,22 @@ import (
 
 type commit struct {
 	pbMsg *pb.Commit
+	prep  messages.Prepare
 }
 
 func newCommit(r uint32, prep messages.Prepare) *commit {
-	return &commit{pbMsg: &pb.Commit{
-		ReplicaId: r,
-		Prepare:   pbPrepareFromAPI(prep),
-	}}
+	return &commit{
+		pbMsg: &pb.Commit{
+			ReplicaId: r,
+			Prepare:   pbPrepareFromAPI(prep),
+		},
+		prep: prep,
+	}
 }
 
 func newCommitFromPb(pbMsg *pb.Commit) *commit {
-	return &commit{pbMsg: pbMsg}
+	prep := newPrepareFromPb(pbMsg.GetPrepare())
+	return &commit{pbMsg: pbMsg, prep: prep}
 }
 
 func (m *commit) MarshalBinary() ([]byte, error) {
@@ -43,7 +48,7 @@ func (m *commit) ReplicaID() uint32 {
 }
 
 func (m *commit) Prepare() messages.Prepare {
-	return newPrepareFromPb(m.pbMsg.GetPrepare())
+	return m.prep
 }
 
 func (m *commit) UIBytes() []byte {

--- a/messages/protobuf/commit_test.go
+++ b/messages/protobuf/commit_test.go
@@ -33,11 +33,11 @@ func TestCommit(t *testing.T) {
 		require.Equal(t, r, comm.ReplicaID())
 		requirePrepEqual(t, prep, comm.Prepare())
 	})
-	t.Run("SetUIBytes", func(t *testing.T) {
+	t.Run("SetUI", func(t *testing.T) {
 		comm := randComm(impl)
-		uiBytes := randUI(messages.AuthenBytes(comm))
-		comm.SetUIBytes(uiBytes)
-		require.Equal(t, uiBytes, comm.UIBytes())
+		ui := randUI(messages.AuthenBytes(comm))
+		comm.SetUI(ui)
+		require.Equal(t, ui, comm.UI())
 	})
 	t.Run("Marshaling", func(t *testing.T) {
 		comm := randComm(impl)
@@ -51,13 +51,12 @@ func randComm(impl messages.MessageImpl) messages.Commit {
 
 func newTestComm(impl messages.MessageImpl, r uint32, prep messages.Prepare, cv uint64) messages.Commit {
 	comm := impl.NewCommit(r, prep)
-	uiBytes := newTestUI(cv, messages.AuthenBytes(comm))
-	comm.SetUIBytes(uiBytes)
+	comm.SetUI(newTestUI(cv, messages.AuthenBytes(comm)))
 	return comm
 }
 
 func requireCommEqual(t *testing.T, comm1, comm2 messages.Commit) {
 	require.Equal(t, comm1.ReplicaID(), comm2.ReplicaID())
 	requirePrepEqual(t, comm1.Prepare(), comm2.Prepare())
-	require.Equal(t, comm1.UIBytes(), comm2.UIBytes())
+	require.Equal(t, comm1.UI(), comm2.UI())
 }

--- a/messages/protobuf/hello.go
+++ b/messages/protobuf/hello.go
@@ -28,8 +28,8 @@ func newHello(r uint32) *hello {
 	}}
 }
 
-func newHelloFromPb(pbMsg *pb.Hello) *hello {
-	return &hello{pbMsg: pbMsg}
+func newHelloFromPb(pbMsg *pb.Hello) (*hello, error) {
+	return &hello{pbMsg: pbMsg}, nil
 }
 
 func (m *hello) MarshalBinary() ([]byte, error) {

--- a/messages/protobuf/impl.go
+++ b/messages/protobuf/impl.go
@@ -68,17 +68,17 @@ func (*impl) NewReqViewChange(r uint32, nv uint64) messages.ReqViewChange {
 func typedMessageFromPb(pbMsg *pb.Message) (messages.Message, error) {
 	switch t := pbMsg.Typed.(type) {
 	case *pb.Message_Hello:
-		return newHelloFromPb(t.Hello), nil
+		return newHelloFromPb(t.Hello)
 	case *pb.Message_Request:
-		return newRequestFromPb(t.Request), nil
+		return newRequestFromPb(t.Request)
 	case *pb.Message_Reply:
-		return newReplyFromPb(t.Reply), nil
+		return newReplyFromPb(t.Reply)
 	case *pb.Message_Prepare:
-		return newPrepareFromPb(t.Prepare), nil
+		return newPrepareFromPb(t.Prepare)
 	case *pb.Message_Commit:
-		return newCommitFromPb(t.Commit), nil
+		return newCommitFromPb(t.Commit)
 	case *pb.Message_ReqViewChange:
-		return newReqViewChangeFromPb(t.ReqViewChange), nil
+		return newReqViewChangeFromPb(t.ReqViewChange)
 	default:
 		return nil, xerrors.New("unknown message type")
 	}

--- a/messages/protobuf/pb/utils.go
+++ b/messages/protobuf/pb/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"github.com/hyperledger-labs/minbft/messages"
+	"github.com/hyperledger-labs/minbft/usig"
 )
 
 func MarshalOrPanic(m proto.Message) []byte {
@@ -48,6 +49,6 @@ func PrepareFromAPI(prep messages.Prepare) *Prepare {
 		ReplicaId: prep.ReplicaID(),
 		View:      prep.View(),
 		Request:   RequestFromAPI(prep.Request()),
-		Ui:        prep.UIBytes(),
+		Ui:        usig.MustMarshalUI(prep.UI()),
 	}
 }

--- a/messages/protobuf/prepare.go
+++ b/messages/protobuf/prepare.go
@@ -21,18 +21,23 @@ import (
 
 type prepare struct {
 	pbMsg *pb.Prepare
+	req   messages.Request
 }
 
 func newPrepare(r uint32, v uint64, req messages.Request) *prepare {
-	return &prepare{pbMsg: &pb.Prepare{
-		ReplicaId: r,
-		View:      v,
-		Request:   pbRequestFromAPI(req),
-	}}
+	return &prepare{
+		pbMsg: &pb.Prepare{
+			ReplicaId: r,
+			View:      v,
+			Request:   pbRequestFromAPI(req),
+		},
+		req: req,
+	}
 }
 
 func newPrepareFromPb(pbMsg *pb.Prepare) *prepare {
-	return &prepare{pbMsg: pbMsg}
+	req := newRequestFromPb(pbMsg.GetRequest())
+	return &prepare{pbMsg: pbMsg, req: req}
 }
 
 func (m *prepare) MarshalBinary() ([]byte, error) {
@@ -48,7 +53,7 @@ func (m *prepare) View() uint64 {
 }
 
 func (m *prepare) Request() messages.Request {
-	return newRequestFromPb(m.pbMsg.GetRequest())
+	return m.req
 }
 
 func (m *prepare) UIBytes() []byte {

--- a/messages/protobuf/prepare_test.go
+++ b/messages/protobuf/prepare_test.go
@@ -35,11 +35,11 @@ func TestPrepare(t *testing.T) {
 		require.Equal(t, v, prep.View())
 		requireReqEqual(t, req, prep.Request())
 	})
-	t.Run("SetUIBytes", func(t *testing.T) {
+	t.Run("SetUI", func(t *testing.T) {
 		prep := randPrep(impl)
-		uiBytes := randUI(messages.AuthenBytes(prep))
-		prep.SetUIBytes(uiBytes)
-		require.Equal(t, uiBytes, prep.UIBytes())
+		ui := randUI(messages.AuthenBytes(prep))
+		prep.SetUI(ui)
+		require.Equal(t, ui, prep.UI())
 	})
 	t.Run("Marshaling", func(t *testing.T) {
 		prep := randPrep(impl)
@@ -53,8 +53,7 @@ func randPrep(impl messages.MessageImpl) messages.Prepare {
 
 func newTestPrep(impl messages.MessageImpl, r uint32, v uint64, req messages.Request, cv uint64) messages.Prepare {
 	prep := impl.NewPrepare(r, v, req)
-	uiBytes := newTestUI(cv, messages.AuthenBytes(prep))
-	prep.SetUIBytes(uiBytes)
+	prep.SetUI(newTestUI(cv, messages.AuthenBytes(prep)))
 	return prep
 }
 
@@ -62,5 +61,5 @@ func requirePrepEqual(t *testing.T, prep1, prep2 messages.Prepare) {
 	require.Equal(t, prep1.ReplicaID(), prep2.ReplicaID())
 	require.Equal(t, prep1.View(), prep2.View())
 	requireReqEqual(t, prep1.Request(), prep2.Request())
-	require.Equal(t, prep1.UIBytes(), prep2.UIBytes())
+	require.Equal(t, prep1.UI(), prep2.UI())
 }

--- a/messages/protobuf/reply.go
+++ b/messages/protobuf/reply.go
@@ -31,8 +31,8 @@ func newReply(r, cl uint32, seq uint64, res []byte) *reply {
 	}}
 }
 
-func newReplyFromPb(pbMsg *pb.Reply) *reply {
-	return &reply{pbMsg: pbMsg}
+func newReplyFromPb(pbMsg *pb.Reply) (*reply, error) {
+	return &reply{pbMsg: pbMsg}, nil
 }
 
 func (m *reply) MarshalBinary() ([]byte, error) {

--- a/messages/protobuf/req-view-change.go
+++ b/messages/protobuf/req-view-change.go
@@ -29,8 +29,8 @@ func newReqViewChange(r uint32, nv uint64) *reqViewChange {
 	}}
 }
 
-func newReqViewChangeFromPb(pbMsg *pb.ReqViewChange) *reqViewChange {
-	return &reqViewChange{pbMsg: pbMsg}
+func newReqViewChangeFromPb(pbMsg *pb.ReqViewChange) (*reqViewChange, error) {
+	return &reqViewChange{pbMsg: pbMsg}, nil
 }
 
 func (m *reqViewChange) MarshalBinary() ([]byte, error) {

--- a/messages/protobuf/request.go
+++ b/messages/protobuf/request.go
@@ -31,8 +31,8 @@ func newRequest(cl uint32, seq uint64, op []byte) *request {
 	}}
 }
 
-func newRequestFromPb(pbMsg *pb.Request) *request {
-	return &request{pbMsg: pbMsg}
+func newRequestFromPb(pbMsg *pb.Request) (*request, error) {
+	return &request{pbMsg: pbMsg}, nil
 }
 
 func (m *request) MarshalBinary() ([]byte, error) {

--- a/messages/protobuf/testutils_test.go
+++ b/messages/protobuf/testutils_test.go
@@ -45,18 +45,13 @@ func remarshalMsg(impl messages.MessageImpl, msg messages.Message) messages.Mess
 	return msg2
 }
 
-func newTestUI(cv uint64, data []byte) []byte {
-	ui := &usig.UI{
+func newTestUI(cv uint64, data []byte) *usig.UI {
+	return &usig.UI{
 		Counter: cv,
+		Cert:    testSig([]byte(fmt.Sprintf("%d:%x", cv, data))),
 	}
-	ui.Cert = testSig([]byte(fmt.Sprintf("%d:%x", ui.Counter, data)))
-	uiBytes, err := ui.MarshalBinary()
-	if err != nil {
-		panic(err)
-	}
-	return uiBytes
 }
 
-func randUI(data []byte) []byte {
+func randUI(data []byte) *usig.UI {
 	return newTestUI(rand.Uint64(), data)
 }

--- a/messages/utils.go
+++ b/messages/utils.go
@@ -16,8 +16,6 @@ package messages
 
 import (
 	"fmt"
-
-	"github.com/hyperledger-labs/minbft/usig"
 )
 
 const maxStringWidth = 256
@@ -25,14 +23,10 @@ const maxStringWidth = 256
 // Stringify returns a human-readable string representing the message
 // content that is sufficient for diagnostic output.
 func Stringify(msg Message) string {
-	ui := new(usig.UI)
+	var cv uint64
 	if msg, ok := msg.(CertifiedMessage); ok {
-		uiBytes := msg.UIBytes()
-		if uiBytes != nil {
-			_ = ui.UnmarshalBinary(uiBytes)
-		}
+		cv = msg.UI().Counter
 	}
-	cv := ui.Counter
 
 	switch msg := msg.(type) {
 	case Hello:

--- a/usig/usig.go
+++ b/usig/usig.go
@@ -84,3 +84,19 @@ func (ui *UI) UnmarshalBinary(in []byte) error {
 
 	return nil
 }
+
+func MustMarshalUI(ui *UI) []byte {
+	uiBytes, err := ui.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return uiBytes
+}
+
+func MustUnmarshalUI(in []byte) *UI {
+	ui := new(UI)
+	if err := ui.UnmarshalBinary(in); err != nil {
+		panic(err)
+	}
+	return ui
+}


### PR DESCRIPTION
<!-- NOTE: Please check the contribution guideline before submitting -->

<!-- describe the purpose of the pull request, as well as its benefits
     and possible concerns related to the proposed changes -->
This pull request improves the code base by removing duplicate parsing of message UI. This will also simplify further changes that I am preparing to submit.

Note that, although most of duplicate UI un-/marshalling is eliminated here, it still remains when generating/verifying UI. This is because UI generation/verification uses `api.Authenticator` via the same interface as generating/verifying normal signatures. We might like to improve this further by adjusting the API to operate on `usig.UI` structure directly.