### PR TITLE
Detect commitment after view termination

### DIFF
--- a/core/commit.go
+++ b/core/commit.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/hyperledger-labs/minbft/core/internal/requestlist"
 	"github.com/hyperledger-labs/minbft/messages"
 )
 
@@ -99,7 +98,7 @@ func makeCommitApplier(collectCommitment commitmentCollector) commitApplier {
 
 // makeCommitmentCollector constructs an instance of
 // commitmentCollector using the supplied abstractions.
-func makeCommitmentCollector(countCommitment commitmentCounter, retireSeq requestSeqRetirer, pendingReq requestlist.List, stopReqTimer requestTimerStopper, executeRequest requestExecutor) commitmentCollector {
+func makeCommitmentCollector(countCommitment commitmentCounter, executeRequest requestExecutor) commitmentCollector {
 	var lock sync.Mutex
 
 	return func(replicaID uint32, prepare messages.Prepare) error {
@@ -112,15 +111,7 @@ func makeCommitmentCollector(countCommitment commitmentCounter, retireSeq reques
 			return nil
 		}
 
-		request := prepare.Request()
-
-		if new := retireSeq(request); !new {
-			return nil // request already accepted for execution
-		}
-
-		pendingReq.Remove(request.ClientID())
-		stopReqTimer(request)
-		executeRequest(request)
+		executeRequest(prepare.Request())
 
 		return nil
 	}

--- a/core/message-handling.go
+++ b/core/message-handling.go
@@ -157,9 +157,10 @@ func defaultMessageHandlers(id uint32, log messagelog.MessageLog, unicastLogs ma
 	startPrepTimer := makePrepareTimerStarter(n, clientStates, unicastLogs, logger)
 	stopPrepTimer := makePrepareTimerStopper(clientStates)
 
+	acceptCommitment := makeCommitmentAcceptor()
 	countCommitment := makeCommitmentCounter(f)
 	executeRequest := makeRequestExecutor(id, retireSeq, pendingReq, stopReqTimer, stack, handleGeneratedMessage)
-	collectCommitment := makeCommitmentCollector(countCommitment, executeRequest)
+	collectCommitment := makeCommitmentCollector(acceptCommitment, countCommitment, executeRequest)
 
 	validateRequest := makeRequestValidator(verifyMessageSignature)
 	validatePrepare := makePrepareValidator(n, verifyUI, validateRequest)

--- a/core/message-handling.go
+++ b/core/message-handling.go
@@ -158,8 +158,8 @@ func defaultMessageHandlers(id uint32, log messagelog.MessageLog, unicastLogs ma
 	stopPrepTimer := makePrepareTimerStopper(clientStates)
 
 	countCommitment := makeCommitmentCounter(f)
-	executeRequest := makeRequestExecutor(id, stack, handleGeneratedMessage)
-	collectCommitment := makeCommitmentCollector(countCommitment, retireSeq, pendingReq, stopReqTimer, executeRequest)
+	executeRequest := makeRequestExecutor(id, retireSeq, pendingReq, stopReqTimer, stack, handleGeneratedMessage)
+	collectCommitment := makeCommitmentCollector(countCommitment, executeRequest)
 
 	validateRequest := makeRequestValidator(verifyMessageSignature)
 	validatePrepare := makePrepareValidator(n, verifyUI, validateRequest)

--- a/core/message-handling.go
+++ b/core/message-handling.go
@@ -158,8 +158,7 @@ func defaultMessageHandlers(id uint32, log messagelog.MessageLog, unicastLogs ma
 	stopPrepTimer := makePrepareTimerStopper(clientStates)
 
 	countCommitment := makeCommitmentCounter(f)
-	executeOperation := makeOperationExecutor(stack)
-	executeRequest := makeRequestExecutor(id, executeOperation, handleGeneratedMessage)
+	executeRequest := makeRequestExecutor(id, stack, handleGeneratedMessage)
 	collectCommitment := makeCommitmentCollector(countCommitment, retireSeq, pendingReq, stopReqTimer, executeRequest)
 
 	validateRequest := makeRequestValidator(verifyMessageSignature)

--- a/core/prepare.go
+++ b/core/prepare.go
@@ -74,14 +74,12 @@ func makePrepareApplier(id uint32, prepareSeq requestSeqPreparer, collectCommitm
 			return fmt.Errorf("Request already prepared")
 		}
 
-		primaryID := prepare.ReplicaID()
-
-		if err := collectCommitment(primaryID, prepare); err != nil {
+		if err := collectCommitment(prepare); err != nil {
 			return fmt.Errorf("Prepare cannot be taken into account: %s", err)
 		}
 
-		if id == primaryID {
-			return nil // primary does not generate Commit
+		if id == prepare.ReplicaID() {
+			return nil // do not generate Commit for own message
 		}
 
 		if !active {

--- a/core/prepare_test.go
+++ b/core/prepare_test.go
@@ -82,8 +82,8 @@ func TestMakePrepareApplier(t *testing.T) {
 		args := mock.MethodCalled("requestSeqPreparer", request)
 		return args.Bool(0)
 	}
-	collectCommitment := func(id uint32, prepare messages.Prepare) error {
-		args := mock.MethodCalled("commitmentCollector", id, prepare)
+	collectCommitment := func(msg messages.CertifiedMessage) error {
+		args := mock.MethodCalled("commitmentCollector", msg)
 		return args.Error(0)
 	}
 	handleGeneratedMessage := func(msg messages.ReplicaMessage) {
@@ -109,29 +109,29 @@ func TestMakePrepareApplier(t *testing.T) {
 	assert.Error(t, err, "Request ID already prepared")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", id, ownPrepare).Return(fmt.Errorf("Error")).Once()
+	mock.On("commitmentCollector", ownPrepare).Return(fmt.Errorf("Error")).Once()
 	err = apply(ownPrepare, true)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", id, ownPrepare).Return(nil).Once()
+	mock.On("commitmentCollector", ownPrepare).Return(nil).Once()
 	err = apply(ownPrepare, true)
 	assert.NoError(t, err)
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", primary, prepare).Return(fmt.Errorf("Error")).Once()
+	mock.On("commitmentCollector", prepare).Return(fmt.Errorf("Error")).Once()
 	err = apply(prepare, true)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", primary, prepare).Return(nil).Once()
+	mock.On("commitmentCollector", prepare).Return(nil).Once()
 	mock.On("prepareTimerStopper", request).Once()
 	mock.On("generatedMessageHandler", commit).Once()
 	err = apply(prepare, true)
 	assert.NoError(t, err)
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", primary, prepare).Return(nil).Once()
+	mock.On("commitmentCollector", prepare).Return(nil).Once()
 	err = apply(prepare, false)
 	assert.NoError(t, err)
 }

--- a/core/request.go
+++ b/core/request.go
@@ -19,7 +19,6 @@ package minbft
 
 import (
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	logging "github.com/op/go-logging"
@@ -67,12 +66,6 @@ type requestApplier func(request messages.Request, view uint64) error
 // operation, produces the corresponding Reply message ready for
 // delivery to the client, and hands it over for further processing.
 type requestExecutor func(request messages.Request)
-
-// operationExecutor executes an operation on the local instance of
-// the replicated state machine. The result of operation execution
-// will be send to the returned channel once it is ready. It is not
-// allowed to invoke concurrently.
-type operationExecutor func(operation []byte) (resultChan <-chan []byte)
 
 // requestSeqCapturer synchronizes beginning of processing of request
 // identifier in Request message.
@@ -214,33 +207,17 @@ func makeRequestReplier(provider clientstate.Provider) requestReplier {
 }
 
 // makeRequestExecutor constructs an instance of requestExecutor using
-// the supplied replica ID, operation executor, message signer, and
-// reply consumer.
-func makeRequestExecutor(id uint32, executor operationExecutor, handleGeneratedMessage generatedMessageHandler) requestExecutor {
+// the supplied replica ID and abstractions.
+func makeRequestExecutor(id uint32, consumer api.RequestConsumer, handleGeneratedMessage generatedMessageHandler) requestExecutor {
 	return func(request messages.Request) {
-		resultChan := executor(request.Operation())
+		resultChan := consumer.Deliver(request.Operation())
+
 		go func() {
 			result := <-resultChan
 
 			reply := messageImpl.NewReply(id, request.ClientID(), request.Sequence(), result)
 			handleGeneratedMessage(reply)
 		}()
-	}
-}
-
-// makeOperationExecutor constructs an instance of operationExecutor
-// using the supplied interface to external request consumer module.
-func makeOperationExecutor(consumer api.RequestConsumer) operationExecutor {
-	busy := uint32(0) // atomic flag to check for concurrent execution
-
-	return func(op []byte) <-chan []byte {
-		if wasBusy := atomic.SwapUint32(&busy, uint32(1)); wasBusy != uint32(0) {
-			panic("Concurrent operation execution detected")
-		}
-		resultChan := consumer.Deliver(op)
-		atomic.StoreUint32(&busy, uint32(0))
-
-		return resultChan
 	}
 }
 


### PR DESCRIPTION
<!-- NOTE: Please check the contribution guideline before submitting -->

<!-- describe the purpose of the pull request, as well as its benefits
     and possible concerns related to the proposed changes -->
This pull request suggests a way to detect a protocol violation when a Byzantine replica continues generating message for a view after it has terminated the view by generating a ViewChange message, as well as to simplify implementation of view change being developed. The proposed change adds an additional requirement on Prepare/Commit message sequence of the same view. It will consequently require to sign Checkpoint messages with a regular signature as opposed to certifying them with USIG. Note that a similar approach was discussed in a paper published in "IEEE Transactions on Computers" journal. Please check commit messages for more details.