### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ install: build
 uninstall:
 	rm -f $(bindir)/keytool
 	rm -f $(bindir)/peer
+	rm -f $(libdir)/libusig_shim.so
 	rm -f $(libdir)/libusig.signed.so
 
 clean: usig-clean


### PR DESCRIPTION
The uninstall target in the Makefile forgot to delete the installed file `libusig_shim.so`.
This patch fix the issue.