### PR TITLE
Decapitalize error strings

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -57,13 +57,13 @@ type Client interface {
 // a stack of external interfaces.
 func New(id uint32, n, f uint32, stack Stack) (Client, error) {
 	if n < f*2+1 {
-		return nil, fmt.Errorf("Insufficient number of replica nodes")
+		return nil, fmt.Errorf("insufficient number of replica nodes")
 	}
 
 	buf := requestbuffer.New()
 
 	if err := startReplicaConnections(id, n, buf, stack); err != nil {
-		return nil, fmt.Errorf("Failed to initiate connections to replicas: %s", err)
+		return nil, fmt.Errorf("failed to initiate connections to replicas: %s", err)
 	}
 
 	seq := makeSequenceGenerator()

--- a/client/message-handling.go
+++ b/client/message-handling.go
@@ -39,7 +39,7 @@ func startReplicaConnections(clientID, n uint32, buf *requestbuffer.T, stack Sta
 		connector := makeReplicaConnector(i, stack)
 		inHandler := makeIncomingMessageHandler(i, handleReply)
 		if err := startReplicaConnection(outHandler, inHandler, connector); err != nil {
-			return fmt.Errorf("Error connecting to replica %d: %s", i, err)
+			return fmt.Errorf("error connecting to replica %d: %s", i, err)
 		}
 	}
 
@@ -115,7 +115,7 @@ func makeReplicaConnector(replicaID uint32, connector api.ReplicaConnector) repl
 	return func(out <-chan []byte) (<-chan []byte, error) {
 		streamHandler := connector.ReplicaMessageStreamHandler(replicaID)
 		if streamHandler == nil {
-			return nil, fmt.Errorf("Connection not possible")
+			return nil, fmt.Errorf("connection not possible")
 		}
 		in := streamHandler.HandleMessageStream(out)
 		return in, nil
@@ -161,7 +161,7 @@ func makeReplyMessageHandler(consumer replyConsumer, authenticator replyAuthenti
 func makeReplyAuthenticator(clientID uint32, authenticator api.Authenticator) replyAuthenticator {
 	return func(reply messages.Reply) error {
 		if reply.ClientID() != clientID {
-			return fmt.Errorf("Client ID mismatch")
+			return fmt.Errorf("client ID mismatch")
 		}
 
 		return authenticator.VerifyMessageAuthenTag(api.ReplicaAuthen, reply.ReplicaID(),

--- a/core/commit.go
+++ b/core/commit.go
@@ -76,11 +76,11 @@ func makeCommitValidator(verifyUI uiVerifier, validatePrepare prepareValidator) 
 		prepare := commit.Prepare()
 
 		if commit.ReplicaID() == prepare.ReplicaID() {
-			return fmt.Errorf("Commit from primary")
+			return fmt.Errorf("commit from primary")
 		}
 
 		if err := validatePrepare(prepare); err != nil {
-			return fmt.Errorf("Invalid Prepare: %s", err)
+			return fmt.Errorf("invalid Prepare: %s", err)
 		}
 
 		if err := verifyUI(commit); err != nil {
@@ -96,7 +96,7 @@ func makeCommitValidator(verifyUI uiVerifier, validatePrepare prepareValidator) 
 func makeCommitApplier(collectCommitment commitmentCollector) commitApplier {
 	return func(commit messages.Commit, active bool) error {
 		if err := collectCommitment(commit); err != nil {
-			return fmt.Errorf("Commit cannot be taken into account: %s", err)
+			return fmt.Errorf("commit cannot be taken into account: %s", err)
 		}
 
 		return nil
@@ -118,7 +118,7 @@ func makeCommitmentCollector(acceptCommitment commitmentAcceptor, countCommitmen
 		case messages.Commit:
 			prepare = msg.Prepare()
 		default:
-			return fmt.Errorf("Unexpected message type")
+			return fmt.Errorf("unexpected message type")
 		}
 
 		view := prepare.View()
@@ -129,7 +129,7 @@ func makeCommitmentCollector(acceptCommitment commitmentAcceptor, countCommitmen
 		defer lock.Unlock()
 
 		if err := acceptCommitment(replicaID, false, view, primaryCV, replicaCV); err != nil {
-			return fmt.Errorf("Cannot accept commitment: %s", err)
+			return fmt.Errorf("cannot accept commitment: %s", err)
 		}
 
 		if done := countCommitment(view, primaryCV); !done {
@@ -152,18 +152,18 @@ func makeCommitmentAcceptor() commitmentAcceptor {
 	return func(replicaID uint32, newView bool, view, primaryCV, replicaCV uint64) error {
 		if newView {
 			if view <= replicaViews[replicaID] {
-				return fmt.Errorf("Unexpected view number")
+				return fmt.Errorf("unexpected view number")
 			}
 			replicaViews[replicaID] = view
 		} else {
 			if view != replicaViews[replicaID] {
-				return fmt.Errorf("Unexpected view number")
+				return fmt.Errorf("unexpected view number")
 			}
 			if primaryCV != lastPrimaryCVs[replicaID]+1 {
-				return fmt.Errorf("Non-sequential primary UI")
+				return fmt.Errorf("non-sequential primary UI")
 			}
 			if replicaCV != lastReplicaCVs[replicaID]+1 {
-				return fmt.Errorf("Non-sequential replica UI")
+				return fmt.Errorf("non-sequential replica UI")
 			}
 		}
 

--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -96,7 +96,7 @@ func TestMakeCommitApplier(t *testing.T) {
 	prepare := messageImpl.NewPrepare(primary, view, request)
 	commit := messageImpl.NewCommit(id, prepare)
 
-	mock.On("commitmentCollector", commit).Return(fmt.Errorf("Error")).Once()
+	mock.On("commitmentCollector", commit).Return(fmt.Errorf("error")).Once()
 	err := apply(commit, true)
 	assert.Error(t, err, "Failed to collect commitment")
 
@@ -143,11 +143,11 @@ func TestMakeCommitmentCollector(t *testing.T) {
 	commit := messageImpl.NewCommit(id, prepare)
 	commit.SetUI(&usig.UI{Counter: backupCV})
 
-	mock.On("commitmentAcceptor", primary, false, view, primaryCV, primaryCV).Return(fmt.Errorf("Error")).Once()
+	mock.On("commitmentAcceptor", primary, false, view, primaryCV, primaryCV).Return(fmt.Errorf("error")).Once()
 	err := collect(prepare)
 	assert.Error(t, err, "Failed to accept Prepare")
 
-	mock.On("commitmentAcceptor", id, false, view, primaryCV, backupCV).Return(fmt.Errorf("Error")).Once()
+	mock.On("commitmentAcceptor", id, false, view, primaryCV, backupCV).Return(fmt.Errorf("error")).Once()
 	err = collect(commit)
 	assert.Error(t, err, "Failed to accept Commit")
 

--- a/core/internal/clientstate/client-state_test.go
+++ b/core/internal/clientstate/client-state_test.go
@@ -55,7 +55,7 @@ func TestProviderConcurrent(t *testing.T) {
 	for i, s1 := range clientStates {
 		for j, s2 := range clientStates[i+1:] {
 			if s1 == s2 && s1 != nil {
-				t.Errorf("Clients %d and %d got the same instance", i, j)
+				t.Errorf("clients %d and %d got the same instance", i, j)
 			}
 		}
 	}

--- a/core/internal/peerstate/peerstate_test.go
+++ b/core/internal/peerstate/peerstate_test.go
@@ -130,7 +130,7 @@ func TestProviderConcurrent(t *testing.T) {
 	for i, s1 := range peerStates {
 		for j, s2 := range peerStates[i+1:] {
 			if s1 == s2 && s1 != nil {
-				t.Errorf("Peers %d and %d got the same instance", i, j)
+				t.Errorf("peers %d and %d got the same instance", i, j)
 			}
 		}
 	}

--- a/core/internal/timer/timer.go
+++ b/core/internal/timer/timer.go
@@ -76,7 +76,7 @@ func (t stdTimer) Expired() <-chan time.Time {
 
 func (t stdTimer) Reset(d time.Duration) {
 	if t.Stop() {
-		panic(fmt.Errorf("Resetting active timer"))
+		panic(fmt.Errorf("resetting active timer"))
 	}
 	t.Timer.Reset(d)
 }

--- a/core/message-handling.go
+++ b/core/message-handling.go
@@ -257,7 +257,7 @@ func startPeerConnections(ownID, n uint32, connector api.ReplicaConnector, handl
 		connect := makePeerConnector(peerID, connector)
 		handleReplyStream := makeMessageStreamHandler(handleMessage, remote, logger)
 		if err := startPeerConnection(ownID, connect, handleReplyStream); err != nil {
-			return fmt.Errorf("Cannot connect to replica %d: %s", peerID, err)
+			return fmt.Errorf("cannot connect to replica %d: %s", peerID, err)
 		}
 	}
 
@@ -294,7 +294,7 @@ func startPeerConnection(ownID uint32, connect peerConnector, handleReplyStream 
 func handleOwnPeerMessages(log messagelog.MessageLog, handleOwnMessage messageHandler, logger *logging.Logger) {
 	for msg := range log.Stream(nil) {
 		if _, new, err := handleOwnMessage(msg); err != nil {
-			panic(fmt.Errorf("Error handling own message: %s", err))
+			panic(fmt.Errorf("error handling own message: %s", err))
 		} else if new {
 			logger.Debugf("Handled own %s", messages.Stringify(msg))
 		}
@@ -307,7 +307,7 @@ func makePeerConnector(peerID uint32, connector api.ReplicaConnector) peerConnec
 	return func(out <-chan []byte) (in <-chan []byte, err error) {
 		sh := connector.ReplicaMessageStreamHandler(peerID)
 		if sh == nil {
-			return nil, fmt.Errorf("Connection not possible")
+			return nil, fmt.Errorf("connection not possible")
 		}
 		return sh.HandleMessageStream(out), nil
 	}
@@ -317,11 +317,11 @@ func makeHelloHandler(ownID, n uint32, messageLog messagelog.MessageLog, unicast
 	return func(msg messages.Message) (<-chan messages.Message, bool, error) {
 		h, ok := msg.(messages.Hello)
 		if !ok {
-			return nil, false, fmt.Errorf("Unexpected message type")
+			return nil, false, fmt.Errorf("unexpected message type")
 		}
 		peerID := h.ReplicaID()
 		if peerID >= n || peerID == ownID {
-			return nil, false, fmt.Errorf("Unexpected peer ID")
+			return nil, false, fmt.Errorf("unexpected peer ID")
 		}
 
 		var replyChan = make(chan messages.Message)
@@ -353,7 +353,7 @@ func makeOwnMessageHandler(process messageProcessor) messageHandler {
 	return func(msg messages.Message) (_ <-chan messages.Message, new bool, err error) {
 		new, err = process(msg)
 		if err != nil {
-			return nil, false, fmt.Errorf("Error processing message: %s", err)
+			return nil, false, fmt.Errorf("error processing message: %s", err)
 		}
 
 		return nil, new, nil
@@ -364,12 +364,12 @@ func makePeerMessageHandler(validate messageValidator, process messageProcessor)
 	return func(msg messages.Message) (_ <-chan messages.Message, new bool, err error) {
 		err = validate(msg)
 		if err != nil {
-			return nil, false, fmt.Errorf("Validation failed: %s", err)
+			return nil, false, fmt.Errorf("validation failed: %s", err)
 		}
 
 		new, err = process(msg)
 		if err != nil {
-			return nil, false, fmt.Errorf("Error processing message: %s", err)
+			return nil, false, fmt.Errorf("error processing message: %s", err)
 		}
 
 		return nil, new, nil
@@ -380,17 +380,17 @@ func makeClientMessageHandler(validateRequest requestValidator, processRequest r
 	return func(msg messages.Message) (_ <-chan messages.Message, new bool, err error) {
 		req, ok := msg.(messages.Request)
 		if !ok {
-			return nil, false, fmt.Errorf("Unexpected message type")
+			return nil, false, fmt.Errorf("unexpected message type")
 		}
 
 		err = validateRequest(req)
 		if err != nil {
-			return nil, false, fmt.Errorf("Invalid Reqeust: %s", err)
+			return nil, false, fmt.Errorf("invalid Reqeust: %s", err)
 		}
 
 		new, err = processRequest(req)
 		if err != nil {
-			return nil, false, fmt.Errorf("Error processing Request: %s", err)
+			return nil, false, fmt.Errorf("error processing Request: %s", err)
 		}
 
 		replyChan := make(chan messages.Message, 1)
@@ -416,7 +416,7 @@ func makeMessageValidator(validateRequest requestValidator, validatePrepare prep
 		case messages.Commit:
 			return validateCommit(msg)
 		case messages.ReqViewChange:
-			return fmt.Errorf("Not implemented")
+			return fmt.Errorf("not implemented")
 		default:
 			panic("Unknown message type")
 		}
@@ -518,14 +518,14 @@ func makeViewMessageProcessor(viewState viewstate.State, applyPeerMessage peerMe
 				// that this replica would transition
 				// into the new view before processing
 				// the message.
-				return false, fmt.Errorf("Message refers to unexpected view")
+				return false, fmt.Errorf("message refers to unexpected view")
 			}
 		default:
 			panic("Unknown message type")
 		}
 
 		if err := applyPeerMessage(msg, active); err != nil {
-			return false, fmt.Errorf("Failed to apply message: %s", err)
+			return false, fmt.Errorf("failed to apply message: %s", err)
 		}
 
 		return true, nil
@@ -576,7 +576,7 @@ func makeGeneratedMessageConsumer(log messagelog.MessageLog, provider clientstat
 			clientID := msg.ClientID()
 			if err := provider(clientID).AddReply(msg); err != nil {
 				// Erroneous Reply must never be supplied
-				panic(fmt.Errorf("Failed to consume generated Reply: %s", err))
+				panic(fmt.Errorf("failed to consume generated Reply: %s", err))
 			}
 		case messages.ReplicaMessage:
 			log.Append(msg)

--- a/core/message-handling_test.go
+++ b/core/message-handling_test.go
@@ -53,7 +53,7 @@ func TestMakeOwnMessageHandler(t *testing.T) {
 		i int
 	}{i: rand.Int()}
 
-	mock.On("messageProcessor", msg).Return(false, fmt.Errorf("Error")).Once()
+	mock.On("messageProcessor", msg).Return(false, fmt.Errorf("error")).Once()
 	_, _, err := handle(msg)
 	assert.Error(t, err)
 
@@ -89,12 +89,12 @@ func TestMakePeerMessageHandler(t *testing.T) {
 		i int
 	}{i: rand.Int()}
 
-	mock.On("messageValidator", msg).Return(fmt.Errorf("Error")).Once()
+	mock.On("messageValidator", msg).Return(fmt.Errorf("error")).Once()
 	_, _, err := handle(msg)
 	assert.Error(t, err)
 
 	mock.On("messageValidator", msg).Return(nil).Once()
-	mock.On("messageProcessor", msg).Return(false, fmt.Errorf("Error")).Once()
+	mock.On("messageProcessor", msg).Return(false, fmt.Errorf("error")).Once()
 	_, _, err = handle(msg)
 	assert.Error(t, err)
 
@@ -149,12 +149,12 @@ func TestMakeClientMessageHandler(t *testing.T) {
 	_, _, err := handle(msg)
 	assert.Error(t, err, "Unexpected message")
 
-	mock.On("requestValidator", req).Return(fmt.Errorf("Error")).Once()
+	mock.On("requestValidator", req).Return(fmt.Errorf("error")).Once()
 	_, _, err = handle(req)
 	assert.Error(t, err)
 
 	mock.On("requestValidator", req).Return(nil).Once()
-	mock.On("requestProcessor", req).Return(false, fmt.Errorf("Error")).Once()
+	mock.On("requestProcessor", req).Return(false, fmt.Errorf("error")).Once()
 	_, _, err = handle(req)
 	assert.Error(t, err)
 
@@ -209,7 +209,7 @@ func TestMakeMessageValidator(t *testing.T) {
 		assert.Panics(t, func() { validateMessage(msg) }, "Unknown message type")
 	})
 	t.Run("Request", func(t *testing.T) {
-		mock.On("requestValidator", request).Return(fmt.Errorf("Error")).Once()
+		mock.On("requestValidator", request).Return(fmt.Errorf("error")).Once()
 		err := validateMessage(request)
 		assert.Error(t, err, "Invalid Request")
 
@@ -218,7 +218,7 @@ func TestMakeMessageValidator(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("Prepare", func(t *testing.T) {
-		mock.On("prepareValidator", prepare).Return(fmt.Errorf("Error")).Once()
+		mock.On("prepareValidator", prepare).Return(fmt.Errorf("error")).Once()
 		err := validateMessage(prepare)
 		assert.Error(t, err, "Invalid Prepare")
 
@@ -227,7 +227,7 @@ func TestMakeMessageValidator(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("Commit", func(t *testing.T) {
-		mock.On("commitValidator", commit).Return(fmt.Errorf("Error")).Once()
+		mock.On("commitValidator", commit).Return(fmt.Errorf("error")).Once()
 		err := validateMessage(commit)
 		assert.Error(t, err, "Invalid Commit")
 
@@ -261,7 +261,7 @@ func TestMakeMessageProcessor(t *testing.T) {
 		assert.Panics(t, func() { process(msg) }, "Unknown message type")
 	})
 	t.Run("Request", func(t *testing.T) {
-		mock.On("requestProcessor", request).Return(false, fmt.Errorf("Error")).Once()
+		mock.On("requestProcessor", request).Return(false, fmt.Errorf("error")).Once()
 		_, err := process(request)
 		assert.Error(t, err, "Failed to process Request")
 
@@ -333,7 +333,7 @@ func TestMakePeerMessageProcessor(t *testing.T) {
 		assert.NoError(t, err)
 
 		mock.On("embeddedMessageProcessor", msg).Once()
-		mock.On("uiMessageProcessor", msg).Return(false, fmt.Errorf("Error")).Once()
+		mock.On("uiMessageProcessor", msg).Return(false, fmt.Errorf("error")).Once()
 		_, err = process(msg)
 		assert.Error(t, err, "Failed to finish processing certified message")
 
@@ -418,7 +418,7 @@ func TestMakeUIMessageProcessor(t *testing.T) {
 	assert.False(t, new)
 
 	mock.On("uiCapturer", uiMsg).Return(true).Once()
-	mock.On("viewMessageProcessor", uiMsg).Return(false, fmt.Errorf("Error")).Once()
+	mock.On("viewMessageProcessor", uiMsg).Return(false, fmt.Errorf("error")).Once()
 	mock.On("uiReleaser", uiMsg).Once()
 	_, err = process(uiMsg)
 	assert.Error(t, err, "Failed to process message in current view")
@@ -536,7 +536,7 @@ func TestMakePeerMessageApplier(t *testing.T) {
 		assert.Panics(t, func() { apply(msg, true) }, "Unknown message type")
 	})
 	t.Run("Prepare", func(t *testing.T) {
-		mock.On("prepareApplier", prepare, true).Return(fmt.Errorf("Error")).Once()
+		mock.On("prepareApplier", prepare, true).Return(fmt.Errorf("error")).Once()
 		err := apply(prepare, true)
 		assert.Error(t, err, "Failed to apply Prepare")
 
@@ -549,7 +549,7 @@ func TestMakePeerMessageApplier(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("Commit", func(t *testing.T) {
-		mock.On("commitApplier", commit, true).Return(fmt.Errorf("Error")).Once()
+		mock.On("commitApplier", commit, true).Return(fmt.Errorf("error")).Once()
 		err := apply(commit, true)
 		assert.Error(t, err, "Failed to apply Commit")
 
@@ -661,7 +661,7 @@ func TestMakeGeneratedMessageConsumer(t *testing.T) {
 		clientState.EXPECT().AddReply(reply).Return(nil)
 		consume(reply)
 
-		clientState.EXPECT().AddReply(reply).Return(fmt.Errorf("Invalid request ID"))
+		clientState.EXPECT().AddReply(reply).Return(fmt.Errorf("invalid request ID"))
 		assert.Panics(t, func() { consume(reply) })
 	})
 	t.Run("PeerMessage", func(t *testing.T) {

--- a/core/prepare_test.go
+++ b/core/prepare_test.go
@@ -55,7 +55,7 @@ func TestMakePrepareValidator(t *testing.T) {
 
 	prepare = messageImpl.NewPrepare(primary, view, request)
 
-	mock.On("requestValidator", request).Return(fmt.Errorf("Invalid signature")).Once()
+	mock.On("requestValidator", request).Return(fmt.Errorf("invalid signature")).Once()
 	err = validate(prepare)
 	assert.Error(t, err)
 
@@ -109,7 +109,7 @@ func TestMakePrepareApplier(t *testing.T) {
 	assert.Error(t, err, "Request ID already prepared")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", ownPrepare).Return(fmt.Errorf("Error")).Once()
+	mock.On("commitmentCollector", ownPrepare).Return(fmt.Errorf("error")).Once()
 	err = apply(ownPrepare, true)
 	assert.Error(t, err, "Failed to collect commitment")
 
@@ -119,7 +119,7 @@ func TestMakePrepareApplier(t *testing.T) {
 	assert.NoError(t, err)
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", prepare).Return(fmt.Errorf("Error")).Once()
+	mock.On("commitmentCollector", prepare).Return(fmt.Errorf("error")).Once()
 	err = apply(prepare, true)
 	assert.Error(t, err, "Failed to collect commitment")
 

--- a/core/replica.go
+++ b/core/replica.go
@@ -75,7 +75,7 @@ func New(id uint32, configer api.Configer, stack Stack, opts ...Option) (api.Rep
 	handleHelloMessage := makeHelloHandler(id, n, messageLog, unicastLogs)
 
 	if err := startPeerConnections(id, n, stack, handlePeerMessage, logger); err != nil {
-		return nil, fmt.Errorf("Failed to start peer connections: %s", err)
+		return nil, fmt.Errorf("failed to start peer connections: %s", err)
 	}
 
 	go handleOwnPeerMessages(messageLog, handleOwnMessage, logger)

--- a/core/request.go
+++ b/core/request.go
@@ -170,7 +170,7 @@ func makeRequestProcessor(captureSeq requestSeqCapturer, pendingReq requestlist.
 		}
 
 		if err := applyRequest(request, currentView); err != nil {
-			return false, fmt.Errorf("Failed to apply Request: %s", err)
+			return false, fmt.Errorf("failed to apply Request: %s", err)
 		}
 
 		return true, nil

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -85,7 +85,7 @@ func TestMakeRequestProcessor(t *testing.T) {
 	viewState.EXPECT().HoldView().Return(view, view, func() {
 		mock.MethodCalled("viewReleaser")
 	})
-	mock.On("requestApplier", request, view).Return(fmt.Errorf("Failed")).Once()
+	mock.On("requestApplier", request, view).Return(fmt.Errorf("failed")).Once()
 	mock.On("viewReleaser").Once()
 	mock.On("requestSeqReleaser", request).Once()
 	_, err = process(request)
@@ -248,7 +248,7 @@ func TestMakeRequestSeqPreparer(t *testing.T) {
 	seq := rand.Uint64()
 	request := messageImpl.NewRequest(expectedClientID, seq, nil)
 
-	state.EXPECT().PrepareRequestSeq(seq).Return(false, fmt.Errorf("Error"))
+	state.EXPECT().PrepareRequestSeq(seq).Return(false, fmt.Errorf("error"))
 	assert.Panics(t, func() { prepareSeq(request) })
 
 	state.EXPECT().PrepareRequestSeq(seq).Return(false, nil)
@@ -272,7 +272,7 @@ func TestMakeRequestSeqRetirer(t *testing.T) {
 	seq := rand.Uint64()
 	request := messageImpl.NewRequest(expectedClientID, seq, nil)
 
-	state.EXPECT().RetireRequestSeq(seq).Return(false, fmt.Errorf("Error"))
+	state.EXPECT().RetireRequestSeq(seq).Return(false, fmt.Errorf("error"))
 	assert.Panics(t, func() { retireSeq(request) })
 
 	state.EXPECT().RetireRequestSeq(seq).Return(false, nil)

--- a/core/usig-ui.go
+++ b/core/usig-ui.go
@@ -63,13 +63,13 @@ func makeUIVerifier(authen api.Authenticator, extractAuthenBytes authenBytesExtr
 	return func(msg messages.CertifiedMessage) error {
 		ui := msg.UI()
 		if ui.Counter == uint64(0) {
-			return fmt.Errorf("Invalid (zero) counter value")
+			return fmt.Errorf("invalid (zero) counter value")
 		}
 
 		authenBytes := extractAuthenBytes(msg)
 		uiBytes := usig.MustMarshalUI(ui)
 		if err := authen.VerifyMessageAuthenTag(api.USIGAuthen, msg.ReplicaID(), authenBytes, uiBytes); err != nil {
-			return fmt.Errorf("Failed verifying USIG certificate: %s", err)
+			return fmt.Errorf("failed verifying USIG certificate: %s", err)
 		}
 
 		return nil

--- a/sample/authentication/authenticator.go
+++ b/sample/authentication/authenticator.go
@@ -94,7 +94,7 @@ func new(roles []api.AuthenticationRole, id uint32, ks BftKeyStorer, usig usig.U
 	for _, r := range ks.NodeRoles() {
 		ksName := ks.NodeKeySpec(r)
 		if (r == api.USIGAuthen) != (ksName == keySpecSgxEcdsa) {
-			return nil, fmt.Errorf("Cannot use %s keyspec for %s role", ksName, r)
+			return nil, fmt.Errorf("cannot use %s keyspec for %s role", ksName, r)
 		}
 		switch ksName {
 		case keySpecEcdsa:
@@ -105,11 +105,11 @@ func new(roles []api.AuthenticationRole, id uint32, ks BftKeyStorer, usig usig.U
 			}
 			sgxUSIG, ok := usig.(*sgxusig.USIG)
 			if !ok {
-				return nil, fmt.Errorf("Cannot use supplied USIG: %s keyspec requires SGX USIG", ksName)
+				return nil, fmt.Errorf("cannot use supplied USIG: %s keyspec requires SGX USIG", ksName)
 			}
 			a.authschemes[r] = NewSGXUSIGAuthenticationScheme(sgxUSIG)
 		default:
-			return nil, fmt.Errorf("Cannot find an authentication scheme corresponding to the keyspec '%s'", ks.KeySpec(r))
+			return nil, fmt.Errorf("cannot find an authentication scheme corresponding to the keyspec '%s'", ks.KeySpec(r))
 		}
 	}
 	return a, nil
@@ -125,10 +125,10 @@ func (a *Authenticator) VerifyMessageAuthenTag(role api.AuthenticationRole, id u
 	}
 	authscheme := a.authschemes[role]
 	if authscheme == nil {
-		return fmt.Errorf("Unknown role: %v", role)
+		return fmt.Errorf("unknown role: %v", role)
 	}
 	if err := authscheme.VerifyAuthenticationTag(msg, authenTag, pk); err != nil {
-		return fmt.Errorf("Invalid authentication tag: %v", err)
+		return fmt.Errorf("invalid authentication tag: %v", err)
 	}
 	return nil
 }

--- a/sample/authentication/crypto.go
+++ b/sample/authentication/crypto.go
@@ -192,7 +192,7 @@ func (au *SGXUSIGAuthenticationScheme) VerifyAuthenticationTag(m []byte, sig []b
 
 	fingerprint, err := makeUSIGKeyFingerprint(pubKey)
 	if err != nil {
-		return fmt.Errorf("Failed to calculate USIG key fingerprint: %s", err)
+		return fmt.Errorf("failed to calculate USIG key fingerprint: %s", err)
 	}
 
 	au.lock.Lock()
@@ -220,13 +220,13 @@ func (au *SGXUSIGAuthenticationScheme) VerifyAuthenticationTag(m []byte, sig []b
 	if !ok && ui.Counter == uint64(1) {
 		epoch, _, err = sgxusig.ParseCert(ui.Cert)
 		if err != nil {
-			return fmt.Errorf("Failed to parse UI certificate: %s", err)
+			return fmt.Errorf("failed to parse UI certificate: %s", err)
 		}
 	}
 
 	usigID, err := sgxusig.MakeID(epoch, pubKey)
 	if err != nil {
-		return fmt.Errorf("Failed to construct USIG identity: %s", err)
+		return fmt.Errorf("failed to construct USIG identity: %s", err)
 	}
 
 	if err := au.usig.VerifyUI(m, &ui, usigID); err != nil {

--- a/sample/authentication/keymanager.go
+++ b/sample/authentication/keymanager.go
@@ -444,7 +444,7 @@ func GenerateTestnetKeys(w io.Writer, opts *TestnetKeyOpts) error {
 	enc := yaml.NewEncoder(w)
 	err = enc.Encode(keys)
 	if err != nil {
-		return fmt.Errorf("Failed to marshal simpleKeyStoreFile to yaml: %v", err)
+		return fmt.Errorf("failed to marshal simpleKeyStoreFile to yaml: %v", err)
 	}
 	return enc.Close()
 }

--- a/sample/authentication/keytool/cmd/generate.go
+++ b/sample/authentication/keytool/cmd/generate.go
@@ -48,7 +48,7 @@ var generateCmd = &cobra.Command{
 		if len(args) > 0 {
 			nrReplicas, err := strconv.Atoi(args[0])
 			if err != nil {
-				return fmt.Errorf("Failed to parse number of replicas "+
+				return fmt.Errorf("failed to parse number of replicas "+
 					"from positional argument: %s", err)
 			}
 			viper.Set("replicas.number", nrReplicas)
@@ -56,7 +56,7 @@ var generateCmd = &cobra.Command{
 		if len(args) > 1 {
 			nrClients, err := strconv.Atoi(args[1])
 			if err != nil {
-				return fmt.Errorf("Failed to parse number of clients "+
+				return fmt.Errorf("failed to parse number of clients "+
 					"from positional argument: %s", err)
 			}
 			viper.Set("clients.number", nrClients)
@@ -112,7 +112,7 @@ func init() {
 func generateKeys() error {
 	usigEnclaveFile, err := envsubst.String(viper.GetString("usig.enclaveFile"))
 	if err != nil {
-		return fmt.Errorf("Failed to parse USIG enclave filename: %s", err)
+		return fmt.Errorf("failed to parse USIG enclave filename: %s", err)
 	}
 	opts := &authen.TestnetKeyOpts{
 		NumberReplicas:  viper.GetInt("replicas.number"),
@@ -131,11 +131,11 @@ func generateKeys() error {
 
 	out, err := os.Create(outFileName)
 	if err != nil {
-		return fmt.Errorf("Failed to open output file: %s", err)
+		return fmt.Errorf("failed to open output file: %s", err)
 	}
 
 	if err := authen.GenerateTestnetKeys(out, opts); err != nil {
-		return fmt.Errorf("Failed to generate keys: %s", err)
+		return fmt.Errorf("failed to generate keys: %s", err)
 	}
 
 	return nil

--- a/sample/conn/grpc/connector/connector.go
+++ b/sample/conn/grpc/connector/connector.go
@@ -73,7 +73,7 @@ func NewReplicaSide() ReplicaConnector {
 func (c *connector) ConnectReplica(replicaID uint32, target string, dialOpts ...grpc.DialOption) error {
 	connection, err := grpc.Dial(target, dialOpts...)
 	if err != nil {
-		return fmt.Errorf("Failed to dial replica: %s", err)
+		return fmt.Errorf("failed to dial replica: %s", err)
 	}
 
 	replica := &replica{

--- a/sample/conn/grpc/server/server.go
+++ b/sample/conn/grpc/server/server.go
@@ -51,7 +51,7 @@ type ReplicaServer interface {
 func ListenAndServe(s ReplicaServer, addr string, serverOpts ...grpc.ServerOption) error {
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
-		return fmt.Errorf("Error listening on %s: %s", addr, err)
+		return fmt.Errorf("error listening on %s: %s", addr, err)
 	}
 	return s.Serve(lis)
 }
@@ -73,7 +73,7 @@ func (s *server) Serve(lis net.Listener, serverOpts ...grpc.ServerOption) error 
 
 	err := s.grpcServer.Serve(lis)
 	if err != nil {
-		return fmt.Errorf("Error serving: %s", err)
+		return fmt.Errorf("error serving: %s", err)
 	}
 	return nil
 }
@@ -117,7 +117,7 @@ func handleStream(stream rpcStream, in chan<- []byte, out <-chan []byte) error {
 			if err == io.EOF {
 				break
 			} else if err != nil {
-				err = fmt.Errorf("Error receiving from server stream: %s", err)
+				err = fmt.Errorf("error receiving from server stream: %s", err)
 				log.Println(err)
 				return err
 			}
@@ -131,7 +131,7 @@ func handleStream(stream rpcStream, in chan<- []byte, out <-chan []byte) error {
 		for msg := range out {
 			err := stream.Send(&proto.Message{Payload: msg})
 			if err != nil {
-				err = fmt.Errorf("Error sending to server stream: %s", err)
+				err = fmt.Errorf("error sending to server stream: %s", err)
 				log.Println(err)
 				return err
 			}

--- a/sample/peer/cmd/request.go
+++ b/sample/peer/cmd/request.go
@@ -89,12 +89,12 @@ func requests(args []string) ([]byte, error) {
 
 	keysFile, err := os.Open(viper.GetString("keys"))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open keyset file: %s", err)
+		return nil, fmt.Errorf("failed to open keyset file: %s", err)
 	}
 
 	auth, err := authen.New([]api.AuthenticationRole{api.ClientAuthen}, id, keysFile)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create authenticator: %s", err)
+		return nil, fmt.Errorf("failed to create authenticator: %s", err)
 	}
 
 	cfg := config.New()
@@ -111,12 +111,12 @@ func requests(args []string) ([]byte, error) {
 	// grpc.WithInsecure() option is passed here for simplicity.
 	err = connector.ConnectManyReplicas(conn, peerAddrs, grpc.WithInsecure())
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to peers: %s", err)
+		return nil, fmt.Errorf("failed to connect to peers: %s", err)
 	}
 
 	client, err := client.New(id, cfg.N(), cfg.F(), clientStack{auth, conn})
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create client instance: %s", err)
+		return nil, fmt.Errorf("failed to create client instance: %s", err)
 	}
 
 	if len(args) > 0 {

--- a/sample/peer/cmd/run.go
+++ b/sample/peer/cmd/run.go
@@ -51,7 +51,7 @@ var runCmd = &cobra.Command{
 		if len(args) > 0 {
 			id, err := strconv.Atoi(args[0])
 			if err != nil {
-				return fmt.Errorf("Failed to parse replica ID "+
+				return fmt.Errorf("failed to parse replica ID "+
 					"from positional argument: %s", err)
 			}
 			viper.Set("replica.id", id)
@@ -93,17 +93,17 @@ func run() error {
 
 	usigEnclaveFile, err := envsubst.String(viper.GetString("usig.enclaveFile"))
 	if err != nil {
-		return fmt.Errorf("Failed to parse USIG enclave filename: %s", err)
+		return fmt.Errorf("failed to parse USIG enclave filename: %s", err)
 	}
 
 	keysFile, err := os.Open(viper.GetString("keys"))
 	if err != nil {
-		return fmt.Errorf("Failed to open keyset file: %s", err)
+		return fmt.Errorf("failed to open keyset file: %s", err)
 	}
 
 	auth, err := authen.NewWithSGXUSIG([]api.AuthenticationRole{api.ReplicaAuthen, api.USIGAuthen}, id, keysFile, usigEnclaveFile)
 	if err != nil {
-		return fmt.Errorf("Failed to create authenticator: %s", err)
+		return fmt.Errorf("failed to create authenticator: %s", err)
 	}
 
 	cfg := config.New()
@@ -124,7 +124,7 @@ func run() error {
 
 	loggingOpts, err := getLoggingOptions()
 	if err != nil {
-		return fmt.Errorf("Failed to create logging options: %s", err)
+		return fmt.Errorf("failed to create logging options: %s", err)
 	}
 
 	conn := connector.NewReplicaSide()
@@ -132,12 +132,12 @@ func run() error {
 	// XXX: The connection destination should be authenticated;
 	// grpc.WithInsecure() option is passed here for simplicity.
 	if err = connector.ConnectManyReplicas(conn, peerAddrs, grpc.WithInsecure()); err != nil {
-		return fmt.Errorf("Failed to connect to peers: %s", err)
+		return fmt.Errorf("failed to connect to peers: %s", err)
 	}
 
 	replica, err := minbft.New(id, cfg, &replicaStack{conn, auth, ledger}, loggingOpts...)
 	if err != nil {
-		return fmt.Errorf("Failed to create replica instance: %s", err)
+		return fmt.Errorf("failed to create replica instance: %s", err)
 	}
 	replicaServer := server.New(replica)
 
@@ -149,7 +149,7 @@ func run() error {
 		// appropriate gRPC server options are omitted here
 		// for simplicity.
 		if err := server.ListenAndServe(replicaServer, listenAddr); err != nil {
-			err = fmt.Errorf("Network server failed: %s", err)
+			err = fmt.Errorf("network server failed: %s", err)
 			fmt.Println(err)
 			srvErrChan <- err
 		}
@@ -164,7 +164,7 @@ func getLoggingOptions() ([]minbft.Option, error) {
 	if viper.GetString("logging.level") != "" {
 		logLevel, err := logging.LogLevel(viper.GetString("logging.level"))
 		if err != nil {
-			return nil, fmt.Errorf("Failed to set logging level: %s", err)
+			return nil, fmt.Errorf("failed to set logging level: %s", err)
 		}
 		opts = append(opts, minbft.WithLogLevel(logLevel))
 	}
@@ -172,7 +172,7 @@ func getLoggingOptions() ([]minbft.Option, error) {
 	if viper.GetString("logging.file") != "" {
 		logFile, err := os.OpenFile(viper.GetString("logging.file"), os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to open logging file: %s", err)
+			return nil, fmt.Errorf("failed to open logging file: %s", err)
 		}
 		opts = append(opts, minbft.WithLogFile(logFile))
 	}


### PR DESCRIPTION
resolves #105

----

This patch revises the first letter of the error log in "fmt.Errorf()" to lowercase.
In addition, words with uppercase meaning such as "Request" and "UI" are not revised.

Signed-off-by: Akiyoshi Tashiro <a_tashiro_29@nec.com>

----

This pull request is to lowercase the first letter of the error log in "fmt.Errorf ()".

@sergefdrv san, Thank you for [your comment](https://github.com/hyperledger-labs/minbft/issues/105#issuecomment-709902397).
I tried to fix "#106" together, but I thought there was something to discuss, so I revised it from #105 first.