### PR TITLE
Update the CI & the Docker environment

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,9 +15,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
-      - name: Print Go version
-        run: |
-          go version
       - name: Install GolangCI-Lint
         run: |
           curl -sfL $GOLANGCI_LINT_URL | sudo sh -s -- -b /usr/local/bin

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 env:
   SGX_SDK_URL: https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.101.2.bin
   GOLANGCI_LINT_URL: https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-  GOLANGCI_LINT_VERSION: v1.27.0
   SGX_MODE: SIM
 
 jobs:
@@ -28,7 +27,7 @@ jobs:
           go version
       - name: Install GolangCI-Lint
         run: |
-          curl -sfL $GOLANGCI_LINT_URL | sudo sh -s -- -b /usr/local/bin $GOLANGCI_LINT_VERSION
+          curl -sfL $GOLANGCI_LINT_URL | sudo sh -s -- -b /usr/local/bin
       - uses: actions/checkout@v2
       - name: Test
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,11 +6,12 @@ env:
 
 jobs:
   build:
-    name: Build with Go ${{ matrix.go }}
-    runs-on: ubuntu-18.04
+    name: Build with Go ${{ matrix.go }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [1.11, 1.14]
+        os: [ubuntu-18.04, ubuntu-20.04]
+        go: [1.11, 1.15]
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,6 @@
 name: Continuous integration
 on: [push, pull_request]
 env:
-  SGX_SDK_URL: https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.101.2.bin
   GOLANGCI_LINT_URL: https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
   SGX_MODE: SIM
 
@@ -13,12 +12,6 @@ jobs:
       matrix:
         go: [1.11, 1.14]
     steps:
-      - name: Install Intel SGX SDK
-        run: |
-          curl -s $SGX_SDK_URL -o sgx_linux_x64_sdk.bin
-          chmod +x sgx_linux_x64_sdk.bin
-          echo -e "no\n/opt/intel" | sudo ./sgx_linux_x64_sdk.bin
-          rm sgx_linux_x64_sdk.bin
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
@@ -29,6 +22,9 @@ jobs:
         run: |
           curl -sfL $GOLANGCI_LINT_URL | sudo sh -s -- -b /usr/local/bin
       - uses: actions/checkout@v2
+      - name: Install Intel SGX SDK
+        run: |
+          sudo ./tools/install-sgx-sdk.sh
       - name: Test
         run: |
           source /opt/intel/sgxsdk/environment

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ and 1.14). For installation instructions please visit
 ### Intel® SGX SDK ###
 
 The Intel® SGX enclave implementation has been tested with Intel® SGX
-SDK for Linux version 2.9.1. For installation instuctions please visit
+SDK for Linux version 2.12. For installation instuctions please visit
 [download page][sgx-downloads].
 Please note that Intel SGX has two operation modes and required software
 components depend on operation mode.

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ To run the containers, the following software must be installed on your
 system.
 
  - [Docker Engine](https://docs.docker.com/engine/) (tested with version
-   19.03.6)
+   19.03.8)
  - [Docker Compose](https://docs.docker.com/compose/) (tested with
-   version 1.17.1)
+   version 1.25.0)
 
-If you are using Ubuntu 18.04, they can be installed as follows:
+If you are using Ubuntu 20.04, they can be installed as follows:
 
 ```sh
 sudo apt-get install docker.io docker-compose

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ sudo make docker-clean
 
 ### Operating System ###
 
-The project has been tested on Ubuntu 18.04 LTS (Bionic Beaver).
+The project has been tested on Ubuntu 18.04 and 20.04 LTS.
 Additional required packages can be installed as follows:
 
 ```sh
@@ -239,7 +239,7 @@ sudo apt-get install build-essential pkg-config
 ### Golang ###
 
 Go 1.11 or later is required to build this project (tested with Go 1.11
-and 1.14). For installation instructions please visit
+and 1.15). For installation instructions please visit
 [this page](https://golang.org/doc/install).
 
 ### Intel® SGX SDK ###

--- a/sample/docker/Dockerfile
+++ b/sample/docker/Dockerfile
@@ -1,24 +1,18 @@
-FROM ubuntu:18.04 AS build
-COPY --from=golang:1.14.4-buster /usr/local/go /usr/local/go/
+FROM ubuntu:20.04 AS build
+COPY --from=golang:1.15-buster /usr/local/go /usr/local/go/
 ENV PATH /usr/local/go/bin:$PATH
-ENV SGX_SDK_URL https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.9.101.2.bin
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		build-essential \
 		ca-certificates \
-		pkg-config \
-		python \
-		wget \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& wget -q -O sgx_linux_x64_sdk.bin $SGX_SDK_URL \
-	&& chmod +x sgx_linux_x64_sdk.bin \
-	&& echo -e "no\n/opt/intel" | ./sgx_linux_x64_sdk.bin
+		curl \
+		pkg-config
 COPY . minbft/
 ENV SGX_MODE SIM
 RUN cd minbft \
+	&& ./tools/install-sgx-sdk.sh \
 	&& . /opt/intel/sgxsdk/environment \
 	&& make prefix=/opt/minbft install
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		libssl1.1 \
 	&& rm -rf /var/lib/apt/lists/*

--- a/tools/install-sgx-sdk.sh
+++ b/tools/install-sgx-sdk.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+. /etc/os-release
+
+if [ "$ID-$VERSION_ID" = "ubuntu-18.04" ]; then
+    DISTRO="ubuntu18.04-server"
+    apt-get -y install build-essential python
+elif [ "$ID-$VERSION_ID" = "ubuntu-20.04" ]; then
+    DISTRO="ubuntu20.04-server"
+    apt-get -y install build-essential python-is-python3
+else
+    echo "This platform is not supported"
+    exit 1
+fi
+
+URL="https://download.01.org/intel-sgx/sgx-linux/2.12/distro/$DISTRO/sgx_linux_x64_sdk_2.12.100.3.bin"
+TMP_DIR=`mktemp -d`
+PACKAGE="$TMP_DIR/sgx_linux_x64_sdk.bin"
+curl -s "$URL" -o "$PACKAGE"
+if [ $? -ne 0 ]; then
+    echo "Could not download the installer"
+    exit 1
+fi
+chmod +x "$PACKAGE"
+echo -e "no\n/opt/intel" | "$PACKAGE"


### PR DESCRIPTION
Intel released the SGX SDK v2.12, which supports Ubuntu 20.04.

This pull request updates the CI and the Docker environment with the latest SDK, and the latest releases of Ubuntu, Go, golangci-lint. Now the CI run on a combination of Ubuntu 18.04 and 20.04, Go 1.11 and 1.15.

Resolves: #200 
