### PR TITLE
Update CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-* @Naoya-Horiguchi @ynamiki
+* @nhoriguchi @ynamiki
 
-/api/ @sergefdrv @Naoya-Horiguchi
-/client/ @sergefdrv @Naoya-Horiguchi
-/core/ @sergefdrv @Naoya-Horiguchi
-/messages/ @sergefdrv @Naoya-Horiguchi
-/sample/ @sergefdrv @Naoya-Horiguchi
-/usig/ @sergefdrv @Naoya-Horiguchi
+/api/ @sergefdrv @nhoriguchi
+/client/ @sergefdrv @nhoriguchi
+/core/ @sergefdrv @nhoriguchi
+/messages/ @sergefdrv @nhoriguchi
+/sample/ @sergefdrv @nhoriguchi
+/usig/ @sergefdrv @nhoriguchi


### PR DESCRIPTION
I've changed GitHub account name, so let's sync .github/CODEOWNER.

Resolves: #205 
