### PR TITLE
Support obtaining and resetting the message log

### DIFF
--- a/core/internal/messagelog/messagelog.go
+++ b/core/internal/messagelog/messagelog.go
@@ -43,7 +43,7 @@ type MessageLog interface {
 }
 
 type messageLog struct {
-	lock sync.RWMutex
+	sync.RWMutex
 
 	// Messages in order added
 	msgs []messages.Message
@@ -58,8 +58,8 @@ func New() MessageLog {
 }
 
 func (log *messageLog) Append(msg messages.Message) {
-	log.lock.Lock()
-	defer log.lock.Unlock()
+	log.Lock()
+	defer log.Unlock()
 
 	log.msgs = append(log.msgs, msg)
 
@@ -81,16 +81,16 @@ func (log *messageLog) supplyMessages(ch chan<- messages.Message, done <-chan st
 	defer close(ch)
 
 	newAdded := make(chan struct{}, 1)
-	log.lock.Lock()
+	log.Lock()
 	log.newAdded = append(log.newAdded, newAdded)
-	log.lock.Unlock()
+	log.Unlock()
 
 	next := 0
 	for {
-		log.lock.RLock()
+		log.RLock()
 		msgs := log.msgs[next:]
 		next = len(log.msgs)
-		log.lock.RUnlock()
+		log.RUnlock()
 
 		for _, msg := range msgs {
 			select {

--- a/core/internal/messagelog/messagelog.go
+++ b/core/internal/messagelog/messagelog.go
@@ -37,9 +37,12 @@ import (
 // they appear in the log. Closing the channel passed to this function
 // indicates the returned channel should be closed. Nil channel may be
 // passed if there's no need to close the returned channel.
+//
+// Messages returns all messages currently in the log.
 type MessageLog interface {
 	Append(msg messages.Message)
 	Stream(done <-chan struct{}) <-chan messages.Message
+	Messages() []messages.Message
 }
 
 type messageLog struct {
@@ -99,4 +102,11 @@ func (log *messageLog) supplyMessages(ch chan<- messages.Message, done <-chan st
 			return
 		}
 	}
+}
+
+func (log *messageLog) Messages() []messages.Message {
+	log.RLock()
+	defer log.RUnlock()
+
+	return log.msgs
 }

--- a/core/internal/messagelog/messagelog_test.go
+++ b/core/internal/messagelog/messagelog_test.go
@@ -80,6 +80,18 @@ func TestStream(t *testing.T) {
 	assert.False(t, more, "Channel not closed")
 }
 
+func TestMessages(t *testing.T) {
+	const nrMessages = 5
+
+	log := New()
+	msgs := makeManyMsgs(nrMessages)
+
+	for _, msg := range msgs {
+		log.Append(msg)
+	}
+	assert.Equalf(t, msgs, log.Messages(), "Unexpected messages")
+}
+
 func TestConcurrent(t *testing.T) {
 	const nrStreams = 3
 	const nrMessages = 5
@@ -97,8 +109,8 @@ func TestConcurrent(t *testing.T) {
 			ch := log.Stream(done)
 
 			for i, msg := range msgs {
-				assert.Equalf(t, msg, <-ch,
-					"Unexpected message %d from stream %d", i, streamID)
+				assert.Equalf(t, msg, <-ch, "Unexpected message %d from stream %d", i, streamID)
+				assert.Equalf(t, msgs[:i], log.Messages()[:i], "Unexpected messages in the log")
 			}
 
 			close(done)
@@ -137,8 +149,8 @@ func TestWithFaulty(t *testing.T) {
 			}
 
 			for i, msg := range msgs {
-				assert.Equalf(t, msg, <-ch,
-					"Unexpected message %d from stream %d", i, streamID)
+				assert.Equalf(t, msg, <-ch, "Unexpected message %d from stream %d", i, streamID)
+				assert.Equalf(t, msgs[:i], log.Messages()[:i], "Unexpected messages in the log")
 			}
 
 			wg.Done()
@@ -152,15 +164,15 @@ func TestWithFaulty(t *testing.T) {
 	wg.Wait()
 }
 
-func makeManyMsgs(nrMessages int) []messages.ReplicaMessage {
-	msgs := make([]messages.ReplicaMessage, nrMessages)
+func makeManyMsgs(nrMessages int) []messages.Message {
+	msgs := make([]messages.Message, nrMessages)
 	for i := 0; i < nrMessages; i++ {
 		msgs[i] = makeMsg()
 	}
 	return msgs
 }
 
-func makeMsg() messages.ReplicaMessage {
+func makeMsg() messages.Message {
 	return struct {
 		messages.ReplicaMessage
 		i int

--- a/core/internal/messagelog/mocks/mock.go
+++ b/core/internal/messagelog/mocks/mock.go
@@ -59,6 +59,18 @@ func (mr *MockMessageLogMockRecorder) Messages() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Messages", reflect.TypeOf((*MockMessageLog)(nil).Messages))
 }
 
+// Reset mocks base method
+func (m *MockMessageLog) Reset(arg0 []messages.Message) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Reset", arg0)
+}
+
+// Reset indicates an expected call of Reset
+func (mr *MockMessageLogMockRecorder) Reset(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockMessageLog)(nil).Reset), arg0)
+}
+
 // Stream mocks base method
 func (m *MockMessageLog) Stream(arg0 <-chan struct{}) <-chan messages.Message {
 	m.ctrl.T.Helper()

--- a/core/internal/messagelog/mocks/mock.go
+++ b/core/internal/messagelog/mocks/mock.go
@@ -45,6 +45,20 @@ func (mr *MockMessageLogMockRecorder) Append(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Append", reflect.TypeOf((*MockMessageLog)(nil).Append), arg0)
 }
 
+// Messages mocks base method
+func (m *MockMessageLog) Messages() []messages.Message {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Messages")
+	ret0, _ := ret[0].([]messages.Message)
+	return ret0
+}
+
+// Messages indicates an expected call of Messages
+func (mr *MockMessageLogMockRecorder) Messages() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Messages", reflect.TypeOf((*MockMessageLog)(nil).Messages))
+}
+
 // Stream mocks base method
 func (m *MockMessageLog) Stream(arg0 <-chan struct{}) <-chan messages.Message {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- NOTE: Please check the contribution guideline before submitting -->

<!-- describe the purpose of the pull request, as well as its benefits
     and possible concerns related to the proposed changes -->
This pull request extends the message log functionality required to generate `ViewChange` messages.
