### PR TITLE
Specify commit certificate size explicitly

### DIFF
--- a/core/commit.go
+++ b/core/commit.go
@@ -191,10 +191,12 @@ func makeCommitmentAcceptor() commitmentAcceptor {
 	}
 }
 
-func makeCommitmentCounter(f uint32) commitmentCounter {
+// makeCommitmentCounter constructs an instance of commitmentCounter
+// given the commit certificate size.
+func makeCommitmentCounter(commitCertSize uint32) commitmentCounter {
 	var (
 		lastView = uint64(0)
-		highest  = make([]uint64, f)
+		highest  = make([]uint64, commitCertSize-1)
 	)
 
 	return func(view, primaryCV uint64) (done bool) {
@@ -203,7 +205,7 @@ func makeCommitmentCounter(f uint32) commitmentCounter {
 		}
 		if view > lastView {
 			lastView = view
-			highest = make([]uint64, f)
+			highest = make([]uint64, len(highest))
 		}
 
 		for i, cv := range highest {

--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -182,8 +182,9 @@ func TestMakeCommitmentCollectorConcurrent(t *testing.T) {
 	var executedReqs []messages.Request
 	var lastSeq uint64
 
+	commitCertSize := uint32(nrFaulty + 1)
 	acceptCommitment := makeCommitmentAcceptor()
-	countCommitment := makeCommitmentCounter(nrFaulty)
+	countCommitment := makeCommitmentCounter(commitCertSize)
 	executeRequest := func(req messages.Request) {
 		// Real requestExecutor ensures exactly-once
 		// semantics; just imitate this behavior here
@@ -311,7 +312,8 @@ func TestMakeCommitmentCounter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	count := makeCommitmentCounter(uint32(f))
+	commitCertSize := uint32(f + 1)
+	count := makeCommitmentCounter(commitCertSize)
 	for i, c := range cases {
 		desc := fmt.Sprintf("Case #%d", i)
 		done := count(c.View, c.CV)

--- a/core/req-view-change_test.go
+++ b/core/req-view-change_test.go
@@ -98,6 +98,7 @@ func TestMakeReqViewChangeProcessor(t *testing.T) {
 
 func TestMakeReqViewChangeCollector(t *testing.T) {
 	const f = 1
+	const n = 3
 
 	var cases []struct {
 		ID      uint32
@@ -131,7 +132,8 @@ func TestMakeReqViewChangeCollector(t *testing.T) {
 		certs = append(certs, cert)
 	}
 
-	collect := makeReqViewChangeCollector(f)
+	commitCertSize := uint32(f + 1)
+	collect := makeReqViewChangeCollector(commitCertSize, n)
 	for i, c := range cases {
 		desc := fmt.Sprintf("Case #%d", i)
 		new, cert := collect(msgs[i])


### PR DESCRIPTION

This pull request makes the commit certificate size explicit in the code.

<!-- and reference any issues resolved by the pull request, e.g. #123 -->
Related to #215, #178.
