### PR TITLE
Unify verification of messages certified by USIG

### DIFF
--- a/core/commit.go
+++ b/core/commit.go
@@ -26,9 +26,9 @@ import (
 
 // commitValidator validates a Commit message.
 //
-// It authenticates and checks the supplied message for internal
-// consistency. It does not use replica's current state and has no
-// side-effect. It is safe to invoke concurrently.
+// It checks the supplied message for internal consistency. It does
+// not use replica's current state and has no side-effect. It is safe
+// to invoke concurrently.
 type commitValidator func(commit messages.Commit) error
 
 // commitApplier applies Commit message to current replica state.
@@ -71,7 +71,7 @@ type commitmentCounter func(view, primaryCV uint64) (done bool)
 
 // makeCommitValidator constructs an instance of commitValidator using
 // the supplied abstractions.
-func makeCommitValidator(verifyUI uiVerifier) commitValidator {
+func makeCommitValidator() commitValidator {
 	return func(commit messages.Commit) error {
 		prop := commit.Proposal()
 
@@ -83,10 +83,6 @@ func makeCommitValidator(verifyUI uiVerifier) commitValidator {
 		case messages.Prepare:
 		default:
 			panic("Unexpected proposal message type")
-		}
-
-		if err := verifyUI(commit); err != nil {
-			return fmt.Errorf("UI is not valid: %s", err)
 		}
 
 		return nil

--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -43,11 +43,7 @@ func TestMakeCommitValidator(t *testing.T) {
 	primary := primaryID(n, view)
 	backup := randOtherReplicaID(primary, n)
 
-	verifyUI := func(msg messages.CertifiedMessage) error {
-		args := mock.MethodCalled("uiVerifier", msg)
-		return args.Error(0)
-	}
-	validate := makeCommitValidator(verifyUI)
+	validate := makeCommitValidator()
 
 	request := messageImpl.NewRequest(0, rand.Uint64(), nil)
 	prepare := messageImpl.NewPrepare(primary, view, request)
@@ -57,12 +53,6 @@ func TestMakeCommitValidator(t *testing.T) {
 	assert.Error(t, err, "Commit from primary")
 
 	commit = messageImpl.NewCommit(backup, prepare)
-
-	mock.On("uiVerifier", commit).Return(fmt.Errorf("error")).Once()
-	err = validate(commit)
-	assert.Error(t, err, "Invalid UI")
-
-	mock.On("uiVerifier", commit).Return(nil).Once()
 	err = validate(commit)
 	assert.NoError(t, err)
 }

--- a/core/prepare.go
+++ b/core/prepare.go
@@ -25,9 +25,9 @@ import (
 
 // prepareValidator validates a Prepare message.
 //
-// It authenticates and checks the supplied message for internal
-// consistency. It does not use replica's current state and has no
-// side-effect. It is safe to invoke concurrently.
+// It checks the supplied message for internal consistency. It does
+// not use replica's current state and has no side-effect. It is safe
+// to invoke concurrently.
 type prepareValidator func(prepare messages.Prepare) error
 
 // prepareApplier applies Prepare message to current replica state.
@@ -43,17 +43,13 @@ type prepareApplier func(prepare messages.Prepare, active bool) error
 // makePrepareValidator constructs an instance of prepareValidator
 // using n as the total number of nodes, and the supplied abstract
 // interfaces.
-func makePrepareValidator(n uint32, verifyUI uiVerifier) prepareValidator {
+func makePrepareValidator(n uint32) prepareValidator {
 	return func(prepare messages.Prepare) error {
 		replicaID := prepare.ReplicaID()
 		view := prepare.View()
 
 		if !isPrimary(view, replicaID, n) {
 			return fmt.Errorf("Prepare from backup %d for view %d", replicaID, view)
-		}
-
-		if err := verifyUI(prepare); err != nil {
-			return fmt.Errorf("UI not valid: %s", err)
 		}
 
 		return nil

--- a/core/prepare_test.go
+++ b/core/prepare_test.go
@@ -39,23 +39,13 @@ func TestMakePrepareValidator(t *testing.T) {
 
 	request := messageImpl.NewRequest(0, rand.Uint64(), nil)
 
-	verifyUI := func(msg messages.CertifiedMessage) error {
-		args := mock.MethodCalled("uiVerifier", msg)
-		return args.Error(0)
-	}
-	validate := makePrepareValidator(n, verifyUI)
+	validate := makePrepareValidator(n)
 
 	prepare := messageImpl.NewPrepare(backup, view, request)
 	err := validate(prepare)
 	assert.Error(t, err)
 
 	prepare = messageImpl.NewPrepare(primary, view, request)
-
-	mock.On("uiVerifier", prepare).Return(fmt.Errorf("error")).Once()
-	err = validate(prepare)
-	assert.Error(t, err)
-
-	mock.On("uiVerifier", prepare).Return(nil).Once()
 	err = validate(prepare)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This pull request makes verification of messages certified by USIG more generic. This will help to simplify verification of ViewChange and NewView message types.

Related to #178.
