### PR TITLE
NewView message handling prep 2: un-preparing requests

### DIFF
--- a/core/message-handling.go
+++ b/core/message-handling.go
@@ -158,6 +158,7 @@ func defaultMessageHandlers(id uint32, log messagelog.MessageLog, unicastLogs ma
 	captureSeq := makeRequestSeqCapturer(clientStates)
 	prepareSeq := makeRequestSeqPreparer(clientStates)
 	retireSeq := makeRequestSeqRetirer(clientStates)
+	unprepareSeq := makeRequestSeqUnpreparer(clientStates)
 	pendingReq := requestlist.New()
 
 	consumeGeneratedMessage := makeGeneratedMessageConsumer(log, clientStates, logger)
@@ -200,7 +201,7 @@ func defaultMessageHandlers(id uint32, log messagelog.MessageLog, unicastLogs ma
 	processCertifiedMessage := makeCertifiedMessageProcessor(n, processViewMessage, processViewChange)
 
 	collectReqViewChange := makeReqViewChangeCollector(viewChangeCertSize)
-	startViewChange := makeViewChangeStarter(id, viewState, log, handleGeneratedMessage)
+	startViewChange := makeViewChangeStarter(id, viewState, log, unprepareSeq, handleGeneratedMessage)
 	processReqViewChange := makeReqViewChangeProcessor(collectReqViewChange, startViewChange)
 
 	processPeerMessage := makePeerMessageProcessor(n, processCertifiedMessage, processReqViewChange)

--- a/core/req-view-change.go
+++ b/core/req-view-change.go
@@ -113,7 +113,7 @@ func makeReqViewChangeCollector(viewChangeCertSize uint32) reqViewChangeCollecto
 	}
 }
 
-func makeViewChangeStarter(id uint32, viewState viewstate.State, log messagelog.MessageLog, handleGeneratedMessage generatedMessageHandler) viewChangeStarter {
+func makeViewChangeStarter(id uint32, viewState viewstate.State, log messagelog.MessageLog, unprepareReqSeq requestSeqUnpreparer, handleGeneratedMessage generatedMessageHandler) viewChangeStarter {
 	return func(newView uint64, vcCert messages.ViewChangeCert) (ok bool, err error) {
 		ok, release := viewState.AdvanceExpectedView(newView)
 		if !ok {
@@ -130,6 +130,7 @@ func makeViewChangeStarter(id uint32, viewState viewstate.State, log messagelog.
 		log.Reset(nil)
 
 		// TODO: start view-change timer
+		unprepareReqSeq()
 
 		handleGeneratedMessage(messageImpl.NewViewChange(id, newView, msgs, vcCert))
 

--- a/core/req-view-change_test.go
+++ b/core/req-view-change_test.go
@@ -155,7 +155,10 @@ func TestMakeViewChangeStarter(t *testing.T) {
 	handleGenerated := func(msg messages.ReplicaMessage) {
 		mock.MethodCalled("generatedMessageHandler", msg)
 	}
-	start := makeViewChangeStarter(id, viewState, log, handleGenerated)
+	unprepareSeq := func() {
+		mock.MethodCalled("requestSeqUnpreparer")
+	}
+	start := makeViewChangeStarter(id, viewState, log, unprepareSeq, handleGenerated)
 
 	newView := rand.Uint64()
 	cert := messages.ViewChangeCert{
@@ -189,6 +192,7 @@ func TestMakeViewChangeStarter(t *testing.T) {
 	vc := messageImpl.NewViewChange(id, newView, viewLog, cert)
 	log.EXPECT().Messages().Return(msgs)
 	log.EXPECT().Reset(nil)
+	mock.On("requestSeqUnpreparer").Once()
 	mock.On("generatedMessageHandler", vc).Once()
 	mock.On("viewReleaser").Once()
 	ok, err = start(newView, cert)

--- a/core/request.go
+++ b/core/request.go
@@ -94,6 +94,10 @@ type requestSeqPreparer func(request messages.Request) (new bool)
 // previously prepared. It is safe to invoke concurrently.
 type requestSeqRetirer func(request messages.Request) (new bool)
 
+// requestSeqUnpreparer un-prepares any previously prepared but not
+// yet retired request identifier seq.
+type requestSeqUnpreparer func()
+
 // requestTimerStarter starts request timer.
 //
 // A request timeout event is triggered if the request timeout elapses
@@ -271,6 +275,14 @@ func makeRequestSeqRetirer(clientStates clientstate.Provider) requestSeqRetirer 
 		}
 
 		return true
+	}
+}
+
+func makeRequestSeqUnpreparer(clientStates clientstate.Provider) requestSeqUnpreparer {
+	return func() {
+		for _, clientID := range clientStates.Clients() {
+			clientStates.ClientState(clientID).UnprepareRequestSeq()
+		}
 	}
 }
 

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -283,6 +283,27 @@ func TestMakeRequestSeqRetirer(t *testing.T) {
 	assert.True(t, new)
 }
 
+func TestMakeRequestSeqUnpreparer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ids := []uint32{rand.Uint32(), rand.Uint32()}
+	provider := mock_clientstate.NewMockProvider(ctrl)
+	provider.EXPECT().Clients().Return(ids).AnyTimes()
+	states := make([]*mock_clientstate.MockState, len(ids))
+	for i, c := range ids {
+		states[i] = mock_clientstate.NewMockState(ctrl)
+		provider.EXPECT().ClientState(c).Return(states[i]).AnyTimes()
+	}
+
+	unprepareSeq := makeRequestSeqUnpreparer(provider)
+
+	for _, s := range states {
+		s.EXPECT().UnprepareRequestSeq()
+	}
+	unprepareSeq()
+}
+
 func TestMakeRequestReplier(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
This pull request adjusts the client state upon starting view change.

Related to #179 
