### PR TITLE
Apply only messages referring to the current active view

### DIFF
--- a/core/commit.go
+++ b/core/commit.go
@@ -36,9 +36,8 @@ type commitValidator func(commit messages.Commit) error
 // The supplied message is applied to the current replica state by
 // changing the state accordingly and producing any required side
 // effects. The supplied message is assumed to be authentic and
-// internally consistent. Parameter active indicates if the message
-// refers to the active view. It is safe to invoke concurrently.
-type commitApplier func(commit messages.Commit, active bool) error
+// internally consistent. It is safe to invoke concurrently.
+type commitApplier func(commit messages.Commit) error
 
 // commitmentCollector collects replica commitment.
 //
@@ -92,7 +91,7 @@ func makeCommitValidator() commitValidator {
 // makeCommitApplier constructs an instance of commitApplier using the
 // supplied abstractions.
 func makeCommitApplier(collectCommitment commitmentCollector) commitApplier {
-	return func(commit messages.Commit, active bool) error {
+	return func(commit messages.Commit) error {
 		if err := collectCommitment(commit); err != nil {
 			return fmt.Errorf("commit cannot be taken into account: %s", err)
 		}

--- a/core/commit_test.go
+++ b/core/commit_test.go
@@ -77,15 +77,11 @@ func TestMakeCommitApplier(t *testing.T) {
 	commit := messageImpl.NewCommit(id, prepare)
 
 	mock.On("commitmentCollector", commit).Return(fmt.Errorf("error")).Once()
-	err := apply(commit, true)
+	err := apply(commit)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("commitmentCollector", commit).Return(nil).Once()
-	err = apply(commit, false)
-	assert.NoError(t, err)
-
-	mock.On("commitmentCollector", commit).Return(nil).Once()
-	err = apply(commit, true)
+	err = apply(commit)
 	assert.NoError(t, err)
 }
 

--- a/core/prepare_test.go
+++ b/core/prepare_test.go
@@ -81,37 +81,32 @@ func TestMakePrepareApplier(t *testing.T) {
 	commit := messageImpl.NewCommit(id, prepare)
 
 	mock.On("requestSeqPreparer", request).Return(false).Once()
-	err := apply(prepare, true)
+	err := apply(prepare)
 	assert.Error(t, err, "Request ID already prepared")
 
 	mock.On("requestSeqPreparer", request).Return(false).Once()
-	err = apply(ownPrepare, true)
+	err = apply(ownPrepare)
 	assert.Error(t, err, "Request ID already prepared")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
 	mock.On("commitmentCollector", ownPrepare).Return(fmt.Errorf("error")).Once()
-	err = apply(ownPrepare, true)
+	err = apply(ownPrepare)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
 	mock.On("commitmentCollector", ownPrepare).Return(nil).Once()
-	err = apply(ownPrepare, true)
+	err = apply(ownPrepare)
 	assert.NoError(t, err)
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
 	mock.On("commitmentCollector", prepare).Return(fmt.Errorf("error")).Once()
-	err = apply(prepare, true)
+	err = apply(prepare)
 	assert.Error(t, err, "Failed to collect commitment")
 
 	mock.On("requestSeqPreparer", request).Return(true).Once()
 	mock.On("commitmentCollector", prepare).Return(nil).Once()
 	mock.On("prepareTimerStopper", request).Once()
 	mock.On("generatedMessageHandler", commit).Once()
-	err = apply(prepare, true)
-	assert.NoError(t, err)
-
-	mock.On("requestSeqPreparer", request).Return(true).Once()
-	mock.On("commitmentCollector", prepare).Return(nil).Once()
-	err = apply(prepare, false)
+	err = apply(prepare)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This pull request changes the way view messages are applied such that only messages referring to the current active view get applied.

Related to #179, #233.