### PR TITLE
Avoid race between view change and adding pending requests

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -159,10 +159,10 @@ func makeRequestProcessor(captureSeq requestSeqCapturer, pendingReq requestlist.
 		}
 		defer releaseSeq()
 
-		pendingReq.Add(request)
-
 		currentView, expectedView, releaseView := viewState.HoldView()
 		defer releaseView()
+
+		pendingReq.Add(request)
 
 		if currentView != expectedView {
 			return true, nil

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -70,31 +70,31 @@ func TestMakeRequestProcessor(t *testing.T) {
 	assert.False(t, new)
 
 	mock.On("requestSeqCapturer", request).Return(true).Once()
-	pendingReq.EXPECT().Add(request)
 	viewState.EXPECT().HoldView().Return(view, newView, func() {
 		mock.MethodCalled("viewReleaser")
 	})
+	pendingReq.EXPECT().Add(request)
 	mock.On("viewReleaser").Once()
 	mock.On("requestSeqReleaser", request).Once()
 	_, err = process(request)
 	assert.NoError(t, err)
 
 	mock.On("requestSeqCapturer", request).Return(true).Once()
-	pendingReq.EXPECT().Add(request)
 	viewState.EXPECT().HoldView().Return(view, view, func() {
 		mock.MethodCalled("viewReleaser")
 	})
-	mock.On("requestApplier", request, view).Return(fmt.Errorf("failed")).Once()
+	pendingReq.EXPECT().Add(request)
+	mock.On("requestApplier", request, view).Return(fmt.Errorf("error")).Once()
 	mock.On("viewReleaser").Once()
 	mock.On("requestSeqReleaser", request).Once()
 	_, err = process(request)
 	assert.Error(t, err, "Failed to apply Request")
 
 	mock.On("requestSeqCapturer", request).Return(true).Once()
-	pendingReq.EXPECT().Add(request)
 	viewState.EXPECT().HoldView().Return(view, view, func() {
 		mock.MethodCalled("viewReleaser")
 	})
+	pendingReq.EXPECT().Add(request)
 	mock.On("requestApplier", request, view).Return(nil).Once()
 	mock.On("viewReleaser").Once()
 	mock.On("requestSeqReleaser", request).Once()


### PR DESCRIPTION
This pull request eliminates the race condition between view change and adding pending requests.

Related to #179.