### PR TITLE
Remove only matching requests from the request list

### DIFF
--- a/core/internal/requestlist/mocks/mock.go
+++ b/core/internal/requestlist/mocks/mock.go
@@ -60,7 +60,7 @@ func (mr *MockListMockRecorder) All() *gomock.Call {
 }
 
 // Remove mocks base method
-func (m *MockList) Remove(arg0 uint32) {
+func (m *MockList) Remove(arg0 messages.Request) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Remove", arg0)
 }

--- a/core/internal/requestlist/request-list.go
+++ b/core/internal/requestlist/request-list.go
@@ -29,13 +29,12 @@ import (
 // Add method adds Request message to the set. Any previously added
 // Request from the same client will be replaced.
 //
-// Remove method removes Request message of the specified client from
-// the set, if any.
+// Remove method removes the Request message from the set.
 //
 // All method returns all messages currently in the set.
 type List interface {
 	Add(req messages.Request)
-	Remove(clientID uint32)
+	Remove(req messages.Request)
 	All() []messages.Request
 }
 
@@ -60,9 +59,17 @@ func (l *list) Add(req messages.Request) {
 	l.messages[req.ClientID()] = req
 }
 
-func (l *list) Remove(clientID uint32) {
+func (l *list) Remove(req messages.Request) {
+	clientID := req.ClientID()
+
 	l.Lock()
 	defer l.Unlock()
+
+	if lastReq, ok := l.messages[clientID]; !ok {
+		return
+	} else if lastReq.Sequence() != req.Sequence() {
+		return
+	}
 
 	delete(l.messages, clientID)
 }

--- a/core/internal/requestlist/request-list_test.go
+++ b/core/internal/requestlist/request-list_test.go
@@ -42,10 +42,10 @@ func TestList(t *testing.T) {
 - {cid: 0, seq: 1, add: true, list: {0: 1      }}
 - {cid: 1, seq: 2, add: true, list: {0: 1, 1: 2}}
 - {cid: 0, seq: 3, add: true, list: {0: 3, 1: 2}}
-- {cid: 1,         rm:  true, list: {0: 3      }}
+- {cid: 1, seq: 2, rm:  true, list: {0: 3      }}
 - {cid: 1, seq: 3, add: true, list: {0: 3, 1: 3}}
-- {cid: 0,         rm:  true, list: {      1: 3}}
-- {cid: 1,         rm:  true, list: {          }}
+- {cid: 0, seq: 3, rm:  true, list: {      1: 3}}
+- {cid: 1, seq: 3, rm:  true, list: {          }}
 `)
 	if err := yaml.UnmarshalStrict(casesYAML, &cases); err != nil {
 		t.Fatal(err)
@@ -56,11 +56,12 @@ func TestList(t *testing.T) {
 	for i, c := range cases {
 		assertMsg := fmt.Sprintf("case=%d cid=%d seq=%d add=%t rm=%t",
 			i, c.Cid, c.Seq, c.Add, c.Rm)
+		m := messageImpl.NewRequest(uint32(c.Cid), uint64(c.Seq), nil)
 		if c.Add {
-			l.Add(messageImpl.NewRequest(uint32(c.Cid), uint64(c.Seq), nil))
+			l.Add(m)
 		}
 		if c.Rm {
-			l.Remove(uint32(c.Cid))
+			l.Remove(m)
 		}
 		msgs := l.All()
 		require.Len(t, msgs, len(c.List), assertMsg)
@@ -93,7 +94,7 @@ func TestListConcurrent(t *testing.T) {
 				list := l.All()
 				assert.Contains(t, list, m)
 
-				l.Remove(uint32(cid))
+				l.Remove(m)
 
 				list = l.All()
 				assert.NotContains(t, list, m)

--- a/core/request.go
+++ b/core/request.go
@@ -216,7 +216,7 @@ func makeRequestExecutor(id uint32, retireSeq requestSeqRetirer, pendingReq requ
 			return // request already accepted for execution
 		}
 
-		pendingReq.Remove(clientID)
+		pendingReq.Remove(request)
 		stopReqTimer(request)
 
 		resultChan := consumer.Deliver(request.Operation())

--- a/core/request_test.go
+++ b/core/request_test.go
@@ -197,7 +197,7 @@ func TestMakeRequestExecutor(t *testing.T) {
 	resultChan <- expectedResult
 	done := make(chan struct{})
 	mock.On("requestSeqRetirer", request).Return(true).Once()
-	pendingReq.EXPECT().Remove(clientID)
+	pendingReq.EXPECT().Remove(request)
 	mock.On("requestTimerStopper", request).Once()
 	consumer.EXPECT().Deliver(expectedOperation).Return(resultChan)
 	mock.On("generatedMessageHandler", expectedReply).Run(


### PR DESCRIPTION
This pull request adjust the implementation of the request list internal component so that to avoid inadvertently removing more recent requests from the list.

Related to #179.