### PR TITLE
Ignore Reply messages generated for old requests

### DIFF
--- a/core/internal/clientstate/client-state.go
+++ b/core/internal/clientstate/client-state.go
@@ -135,10 +135,9 @@ func (p *provider) Clients() (clientIDs []uint32) {
 // UnprepareRequestSeq un-prepares any previously prepared but not yet
 // retired request identifier seq.
 //
-// AddReply accepts a Reply message. Reply messages should be added in
-// sequence of corresponding request identifiers. Only a single Reply
-// message should be added for each request identifier. It will never
-// be blocked by any of the channels returned from ReplyChannel.
+// AddReply accepts a Reply message. Only the Reply message referring
+// to the highest request identifier is accepted. It will never be
+// blocked by any of the channels returned from ReplyChannel.
 //
 // ReplyChannel returns a channel to receive the Reply message
 // corresponding to the supplied request identifier. The returned
@@ -171,7 +170,7 @@ type State interface {
 	RetireRequestSeq(seq uint64) (new bool, err error)
 	UnprepareRequestSeq()
 
-	AddReply(reply messages.Reply) error
+	AddReply(reply messages.Reply)
 	ReplyChannel(seq uint64) <-chan messages.Reply
 
 	StartRequestTimer(seq uint64, handleTimeout func())

--- a/core/internal/clientstate/mocks/mock.go
+++ b/core/internal/clientstate/mocks/mock.go
@@ -86,11 +86,9 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddReply mocks base method
-func (m *MockState) AddReply(arg0 messages.Reply) error {
+func (m *MockState) AddReply(arg0 messages.Reply) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddReply", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "AddReply", arg0)
 }
 
 // AddReply indicates an expected call of AddReply

--- a/core/internal/clientstate/reply.go
+++ b/core/internal/clientstate/reply.go
@@ -15,7 +15,6 @@
 package clientstate
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/hyperledger-labs/minbft/messages"
@@ -38,14 +37,14 @@ func newReplyState() *replyState {
 	return &replyState{}
 }
 
-func (s *replyState) AddReply(reply messages.Reply) error {
+func (s *replyState) AddReply(reply messages.Reply) {
 	seq := reply.Sequence()
 
 	s.Lock()
 	defer s.Unlock()
 
 	if seq <= s.lastRepliedSeq {
-		return fmt.Errorf("old request ID")
+		return
 	}
 
 	s.reply = reply
@@ -55,8 +54,6 @@ func (s *replyState) AddReply(reply messages.Reply) error {
 		close(ch)
 	}
 	s.replyAdded = nil
-
-	return nil
 }
 
 func (s *replyState) ReplyChannel(seq uint64) <-chan messages.Reply {

--- a/core/internal/clientstate/reply_test.go
+++ b/core/internal/clientstate/reply_test.go
@@ -31,46 +31,8 @@ import (
 var messageImpl = protobufMessages.NewImpl()
 
 func TestReply(t *testing.T) {
-	t.Run("Add", testAddReply)
 	t.Run("Channel", testReplyChannel)
 	t.Run("ChannelConcurrent", testReplyChannelConcurrent)
-}
-
-func testAddReply(t *testing.T) {
-	s := newClientState(timer.Standard(), defaultTimeout, defaultTimeout)
-
-	cases := []struct {
-		desc string
-		seq  int
-
-		ok bool
-	}{{
-		desc: "Add first Reply",
-		seq:  100,
-		ok:   true,
-	}, {
-		desc: "Add duplicate Reply",
-		seq:  100,
-		ok:   false,
-	}, {
-		desc: "Add another Reply",
-		seq:  200,
-		ok:   true,
-	}, {
-		desc: "Add older Reply",
-		seq:  150,
-		ok:   false,
-	}}
-
-	for _, c := range cases {
-		reply := makeReply(uint64(c.seq))
-		err := s.AddReply(reply)
-		if c.ok {
-			require.NoError(t, err, c.desc)
-		} else {
-			require.Error(t, err, c.desc)
-		}
-	}
 }
 
 func testReplyChannel(t *testing.T) {
@@ -84,8 +46,7 @@ func testReplyChannel(t *testing.T) {
 	ch1Seq1 := s.ReplyChannel(seq1)
 	require.NotNil(t, ch1Seq1)
 
-	err := s.AddReply(rly1)
-	require.NoError(t, err)
+	s.AddReply(rly1)
 
 	ch2Seq1 := s.ReplyChannel(seq1)
 	require.NotNil(t, ch2Seq1)
@@ -100,8 +61,7 @@ func testReplyChannel(t *testing.T) {
 	ch1Seq2 := s.ReplyChannel(seq2)
 	require.NotNil(t, ch1Seq2)
 
-	err = s.AddReply(rly2)
-	require.NoError(t, err)
+	s.AddReply(rly2)
 
 	ch3Seq1 := s.ReplyChannel(seq1)
 	require.NotNil(t, ch3Seq1)
@@ -140,8 +100,7 @@ func testReplyChannelConcurrent(t *testing.T) {
 			}()
 		}
 
-		err := s.AddReply(rly)
-		assert.NoError(t, err, "seq=%d", seq)
+		s.AddReply(rly)
 
 		wg.Wait()
 	}

--- a/core/message-handling.go
+++ b/core/message-handling.go
@@ -660,17 +660,13 @@ func makeGeneratedMessageHandler(sign messageSigner, assignUI uiAssigner, consum
 	}
 }
 
-func makeGeneratedMessageConsumer(log messagelog.MessageLog, provider clientstate.Provider, logger logger.Logger) generatedMessageConsumer {
+func makeGeneratedMessageConsumer(log messagelog.MessageLog, clientStates clientstate.Provider, logger logger.Logger) generatedMessageConsumer {
 	return func(msg messages.ReplicaMessage) {
 		logger.Debugf("Generated %s", messages.Stringify(msg))
 
 		switch msg := msg.(type) {
 		case messages.Reply:
-			clientID := msg.ClientID()
-			if err := provider.ClientState(clientID).AddReply(msg); err != nil {
-				// Erroneous Reply must never be supplied
-				panic(fmt.Errorf("failed to consume generated Reply: %s", err))
-			}
+			clientStates.ClientState(msg.ClientID()).AddReply(msg)
 		case messages.ReplicaMessage:
 			log.Append(msg)
 		default:

--- a/core/message-handling_test.go
+++ b/core/message-handling_test.go
@@ -924,11 +924,8 @@ func TestMakeGeneratedMessageConsumer(t *testing.T) {
 	t.Run("Reply", func(t *testing.T) {
 		reply := messageImpl.NewReply(rand.Uint32(), clientID, rand.Uint64(), nil)
 
-		clientState.EXPECT().AddReply(reply).Return(nil)
+		clientState.EXPECT().AddReply(reply)
 		consume(reply)
-
-		clientState.EXPECT().AddReply(reply).Return(fmt.Errorf("invalid request ID"))
-		assert.Panics(t, func() { consume(reply) })
 	})
 	t.Run("PeerMessage", func(t *testing.T) {
 		msg := struct {


### PR DESCRIPTION
This pull request removes excessive error checking when handling generated Reply messages.

Relates to #179.
