### PR TITLE
Increase commit certificate size

### DIFF
--- a/core/message-handling.go
+++ b/core/message-handling.go
@@ -142,7 +142,7 @@ func defaultMessageHandlers(id uint32, log messagelog.MessageLog, unicastLogs ma
 	// size is the number of replicas required to proceed with
 	// view change. Any commit and view-change certificates must
 	// intersect in at least one replica.
-	commitCertSize := f + 1
+	commitCertSize := n - f
 	viewChangeCertSize := n - commitCertSize + 1
 
 	reqTimeout := makeRequestTimeoutProvider(config)


### PR DESCRIPTION
This pull request improves stability of the view-change test. The test [showed](https://github.com/hyperledger-labs/minbft/pull/246#issuecomment-1081827076) that messages generated during view change tend to become very large and their handling takes up too much time.